### PR TITLE
Changing schema from nnumy1ga to pgq2pd26

### DIFF
--- a/apps/cms/sanity.cli.ts
+++ b/apps/cms/sanity.cli.ts
@@ -2,7 +2,7 @@ import { defineCliConfig } from "sanity/cli";
 
 export default defineCliConfig({
   api: {
-    projectId: "nnumy1ga",
+    projectId: "pgq2pd26",
     dataset: "production",
   },
 });

--- a/apps/cms/sanity.config.ts
+++ b/apps/cms/sanity.config.ts
@@ -19,7 +19,7 @@ const defaultConfig = {
     markdownSchema(),
   ],
   schema: { types: schemaTypes },
-  projectId: "nnumy1ga",
+  projectId: "pgq2pd26",
 };
 
 const prodConfig = {


### PR DESCRIPTION
## Why did you create this PR?

The cms data has been migrated from nnumy1ga to pgq2pd26, so we need to update the cms we reference

