### PR TITLE
Mobile text overflow issue fixed 

### DIFF
--- a/apps/web/src/app/(default)/content.tsx
+++ b/apps/web/src/app/(default)/content.tsx
@@ -49,7 +49,7 @@ export async function Content() {
           href="/for-studenter/arrangementer?type=bedpres"
           className="group mx-auto flex items-center underline-offset-4 hover:underline"
         >
-          <h2 className="text-center text-3xl font-medium">Bedriftspresentasjoner</h2>
+          <h2 className="text-center text-2xl font-medium md:text-3xl">Bedriftspresentasjoner</h2>
 
           <ArrowRightIcon className="ml-2 inline h-6 w-6 transition-transform group-hover:translate-x-2" />
         </Link>


### PR DESCRIPTION
## Why did you create this PR?

Bedriftspresentasjoner -> overflow på mobilen fordi teksten var for stor/lang for containeren. 

## How did you solve the problem?

Fiksa det med å gjøre tektsen mindre om den er sett på en mindre skjerm.
Før:
![IMG_5438](https://github.com/echo-webkom/echo-web-mono/assets/60822728/c6344855-f110-4d4c-b7a9-e1c2b8350d8b)
Etter:
<img width="370" alt="image" src="https://github.com/echo-webkom/echo-web-mono/assets/60822728/8ae0b7d0-3edc-47a5-a97a-3eea940c99af">
