### PR TITLE
Update /arrangementer

### DIFF
--- a/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
@@ -98,9 +98,7 @@ export default async function Page({ searchParams }: { searchParams?: SearchPara
 
   return (
     <Container>
-      <div>
-        <EventFilter />
-      </div>
+      <EventFilter />
       <div className="flex flex-col md:flex-row">
         <div className="w-full pr-16 md:max-w-[250px]">
           <EventFilterSidebar numOfEvents={{ numThisWeek, numNextWeek, numLater }} />

--- a/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
@@ -33,37 +33,26 @@ export type SearchParams = {
   later?: string;
 };
 
-// Sanitizes the query params before fetching data
-function generateQuery(params: SearchParams) {
-  const query: FilteredHappeningQuery = {
+/**
+ * Sanitizes the SearchParams before fetching data
+ */
+function createFilteredHappeningQuery(params: SearchParams | undefined) {
+  if (!params) params = { type: "all" };
+
+  return {
     search: params.search ?? undefined,
     type: (params.type as "event" | "bedpres") ?? "all",
     open: params.open === "true" ? true : false,
     past: params.past === "true" ? true : false,
-    dateFilter: getDateInterval(params),
+    dateFilter: getDateIntervals(params),
   };
-
-  return query;
 }
 
-function validateParams(params: SearchParams | undefined) {
-  if (!params) return { type: "all" };
-
-  const validParams: SearchParams = {
-    type: (params.type as "event" | "bedpres") ?? undefined,
-    order: params.order === "ASC" ? "ASC" : undefined,
-    search: params.search ?? undefined,
-    thisWeek: params.thisWeek === "false" ? "false" : undefined,
-    nextWeek: params.nextWeek === "false" ? "false" : undefined,
-    later: params.later === "false" ? "false" : undefined,
-    open: params.open === "true" ? "true" : undefined,
-    past: params.past === "true" ? "true" : undefined,
-  };
-
-  return validParams;
-}
-
-function getDateInterval(params: SearchParams) {
+/**
+ * This function creates an array of DateIntervals.
+ * Will be useful in the future to allow the user to enter custom dates.
+ */
+function getDateIntervals(params: SearchParams) {
   const currentDate = new Date();
 
   const past = params.past === "true" ? true : false;
@@ -94,9 +83,7 @@ function getDateInterval(params: SearchParams) {
 }
 
 export default async function Page({ searchParams }: { searchParams?: SearchParams }) {
-  const validParams = validateParams(searchParams);
-
-  const query = generateQuery(validParams);
+  const query: FilteredHappeningQuery = createFilteredHappeningQuery(searchParams);
   const { numThisWeek, numNextWeek, numLater, happenings } = await fetchFilteredHappening(query);
 
   if (!happenings)
@@ -107,7 +94,7 @@ export default async function Page({ searchParams }: { searchParams?: SearchPara
       </Callout>
     );
 
-  if (validParams.order === "ASC") happenings.reverse();
+  if (searchParams?.order === "ASC") happenings.reverse();
 
   return (
     <Container>

--- a/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
@@ -22,7 +22,7 @@ type DateInterval = {
   end?: Date;
 };
 
-export type SearchParams = {
+type SearchParams = {
   type?: string;
   order?: string;
   search?: string;
@@ -102,7 +102,7 @@ export default async function Page({ searchParams }: { searchParams?: SearchPara
         <EventFilter />
       </div>
       <div className="flex flex-col md:flex-row">
-        <div className="w-full md:max-w-[250px]">
+        <div className="w-full pr-16 md:max-w-[250px]">
           <EventFilterSidebar numOfEvents={{ numThisWeek, numNextWeek, numLater }} />
         </div>
         <div className="w-full">

--- a/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/arrangementer/page.tsx
@@ -99,14 +99,11 @@ export default async function Page({ searchParams }: { searchParams?: SearchPara
   return (
     <Container>
       <div>
-        <EventFilter params={validParams} />
+        <EventFilter />
       </div>
       <div className="flex flex-col md:flex-row">
         <div className="w-full md:max-w-[250px]">
-          <EventFilterSidebar
-            params={validParams}
-            numOfEvents={{ numThisWeek, numNextWeek, numLater }}
-          />
+          <EventFilterSidebar numOfEvents={{ numThisWeek, numNextWeek, numLater }} />
         </div>
         <div className="w-full">
           <EventsView happenings={happenings} />

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -119,7 +119,14 @@ export function EventFilterSidebar({
 
   const inputRef = useRef(false);
 
-  const filterSet = params.toString() !== "";
+  const filterSet =
+    params.has("order") ||
+    params.has("search") ||
+    params.has("open") ||
+    params.has("past") ||
+    params.has("thisWeek") ||
+    params.has("nextWeek") ||
+    params.has("later");
 
   const { thisWeek, nextWeek, later, open } = {
     thisWeek: params.get("thisWeek") === "false" ? false : true,
@@ -160,6 +167,13 @@ export function EventFilterSidebar({
         break;
     }
 
+    router.push(`${pathname}?${searchParams}`, { scroll: false });
+  }
+
+  function resetFilter() {
+    const searchParams = new URLSearchParams();
+    const type = params.get("type");
+    if (type === "bedpres" || type === "event") searchParams.set("type", type);
     router.push(`${pathname}?${searchParams}`, { scroll: false });
   }
 
@@ -263,7 +277,7 @@ export function EventFilterSidebar({
             className={cn("hoved:text-primary-hover cursor-pointer text-base text-primary", {
               invisible: !filterSet,
             })}
-            onClick={() => router.push(`${pathname}`, { scroll: false })}
+            onClick={() => resetFilter()}
           >
             Nullstill alle
           </Label>

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -17,13 +17,15 @@ export function EventFilter() {
   const pathname = usePathname();
   const params = useSearchParams();
 
-  const filter = {
+  const { type, past, asc } = {
     type:
-      params.get("type") === "event" || params.get("type") === "bedpres"
-        ? params.get("type")
-        : "all",
+      params.get("type") === "event"
+        ? "event"
+        : params.get("type") === "bedpres"
+          ? "bedpres"
+          : "all",
     past: params.get("past") === "true" ? true : false,
-    showAsc: params.get("order") === "ASC" ? true : false,
+    asc: params.get("order") === "ASC" ? true : false,
   };
 
   function updateFilter(element: string) {
@@ -40,10 +42,10 @@ export function EventFilter() {
         searchParams.set("type", "bedpres");
         break;
       case "past":
-        filter.past ? searchParams.delete("past") : searchParams.set("past", "true");
+        past ? searchParams.delete("past") : searchParams.set("past", "true");
         break;
       case "order":
-        filter.showAsc ? searchParams.delete("order") : searchParams.set("order", "ASC");
+        asc ? searchParams.delete("order") : searchParams.set("order", "ASC");
         break;
     }
 
@@ -51,26 +53,26 @@ export function EventFilter() {
   }
 
   return (
-    <div className="space-y-5 border-b-2 border-solid border-opacity-20 pb-3">
-      <div className="flex flex-col sm:flex-row sm:justify-between">
+    <div className="">
+      <div className="flex flex-col border-b-2 border-solid border-opacity-20 pb-4 sm:flex-row sm:justify-between">
         <div className="flex flex-col items-center sm:flex-row sm:space-x-2">
           <Button
             className="w-60 sm:w-auto"
-            variant={filter.type === "all" ? "default" : "outline"}
+            variant={type === "all" ? "default" : "outline"}
             onClick={() => updateFilter("all")}
           >
             Alle
           </Button>
           <Button
             className="w-60 sm:w-auto"
-            variant={filter.type === "event" ? "default" : "outline"}
+            variant={type === "event" ? "default" : "outline"}
             onClick={() => updateFilter("event")}
           >
             Arrangementer
           </Button>
           <Button
             className="w-60 sm:w-auto"
-            variant={filter.type === "bedpres" ? "default" : "outline"}
+            variant={type === "bedpres" ? "default" : "outline"}
             onClick={() => updateFilter("bedpres")}
           >
             Bedriftspresentasjoner
@@ -82,15 +84,15 @@ export function EventFilter() {
             variant={"outline"}
             onClick={() => updateFilter("past")}
           >
-            {filter.past ? "Vis kommende" : "Vis tidligere"}
+            {past ? "Vis kommende" : "Vis tidligere"}
           </Button>
         </div>
       </div>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-end pb-2 pt-4">
         <span className="mr-2">
           <ArrowDownNarrowWide
             className={cn("h-6 w-6 cursor-pointer transition duration-200 ease-in-out", {
-              "rotate-180 transform": filter.showAsc,
+              "rotate-180 transform": asc,
             })}
             onClick={() => updateFilter("order")}
           />
@@ -100,23 +102,26 @@ export function EventFilter() {
   );
 }
 
-export function EventFilterSidebar({
-  numOfEvents: { numThisWeek, numNextWeek, numLater },
-}: {
+type EventFilterSidebarProps = {
   numOfEvents: {
     numThisWeek: number;
     numNextWeek: number;
     numLater: number;
   };
-}) {
+};
+
+export function EventFilterSidebar({
+  numOfEvents: { numThisWeek, numNextWeek, numLater },
+}: EventFilterSidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
 
   const inputRef = useRef(false);
 
-  const filter = {
-    search: params.get("search") ?? "",
+  const filterSet = params.toString() !== "";
+
+  const { thisWeek, nextWeek, later, open } = {
     thisWeek: params.get("thisWeek") === "false" ? false : true,
     nextWeek: params.get("nextWeek") === "false" ? false : true,
     later: params.get("later") === "false" ? false : true,
@@ -142,16 +147,16 @@ export function EventFilterSidebar({
 
     switch (element) {
       case "thisWeek":
-        filter.thisWeek ? searchParams.set("thisWeek", "false") : searchParams.delete("thisWeek");
+        thisWeek ? searchParams.set("thisWeek", "false") : searchParams.delete("thisWeek");
         break;
       case "nextWeek":
-        filter.nextWeek ? searchParams.set("nextWeek", "false") : searchParams.delete("nextWeek");
+        nextWeek ? searchParams.set("nextWeek", "false") : searchParams.delete("nextWeek");
         break;
       case "later":
-        filter.later ? searchParams.set("later", "false") : searchParams.delete("later");
+        later ? searchParams.set("later", "false") : searchParams.delete("later");
         break;
       case "open":
-        filter.open ? searchParams.delete("open") : searchParams.set("open", "true");
+        open ? searchParams.delete("open") : searchParams.set("open", "true");
         break;
     }
 
@@ -159,10 +164,10 @@ export function EventFilterSidebar({
   }
 
   return (
-    <Sidebar className="mb-5 mt-5 space-y-3">
+    <Sidebar className="space-y-3">
       <SidebarItem>
         <SidebarItemContent>
-          <div className="relative flex rounded-lg border hover:border-gray-500">
+          <div className="relative flex rounded-lg border border-gray-300 hover:border-gray-500">
             <Input
               value={searchInput}
               onChange={(e) => {
@@ -205,7 +210,7 @@ export function EventFilterSidebar({
           <Checkbox
             className="hover:bg-blue-100"
             id="thisWeek"
-            checked={filter.thisWeek}
+            checked={thisWeek}
             onCheckedChange={() => updateFilter("thisWeek")}
           />
           <Label htmlFor="thisWeek" className="ml-2 cursor-pointer text-sm">
@@ -217,7 +222,7 @@ export function EventFilterSidebar({
           <Checkbox
             className="hover:bg-blue-100"
             id="nextWeek"
-            checked={filter.nextWeek}
+            checked={nextWeek}
             onCheckedChange={() => updateFilter("nextWeek")}
           />
           <Label htmlFor="nextWeek" className="ml-2 cursor-pointer text-sm">
@@ -229,7 +234,7 @@ export function EventFilterSidebar({
           <Checkbox
             className="hover:bg-blue-100"
             id="later"
-            checked={filter.later}
+            checked={later}
             onCheckedChange={() => updateFilter("later")}
           />
           <Label htmlFor="later" className="ml-2 cursor-pointer text-sm">
@@ -244,11 +249,23 @@ export function EventFilterSidebar({
           <Checkbox
             className="hover:bg-blue-100"
             id="showOpen"
-            checked={filter.open}
+            checked={open}
             onCheckedChange={() => updateFilter("open")}
           />
           <Label htmlFor="showOpen" className="ml-2 cursor-pointer text-sm">
             Åpen for påmelding
+          </Label>
+        </SidebarItemContent>
+      </SidebarItem>
+      <SidebarItem className="pt-6">
+        <SidebarItemContent>
+          <Label
+            className={cn("hoved:text-primary-hover cursor-pointer text-base text-primary", {
+              invisible: !filterSet,
+            })}
+            onClick={() => router.push(`${pathname}`, { scroll: false })}
+          >
+            Nullstill alle
           </Label>
         </SidebarItemContent>
       </SidebarItem>

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -279,7 +279,7 @@ export function EventFilterSidebar({
             })}
             onClick={() => resetFilter()}
           >
-            Nullstill alle filtere
+            Nullstill alle filtre
           </Label>
         </SidebarItemContent>
       </SidebarItem>

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -89,9 +89,9 @@ export function EventFilter() {
         </div>
       </div>
       <div className="flex items-center justify-end pb-2 pt-4">
-        <span className="mr-2">
+        <span>
           <ArrowDownNarrowWide
-            className={cn("h-6 w-6 cursor-pointer transition duration-200 ease-in-out", {
+            className={cn("mr-2 h-6 w-6 cursor-pointer transition duration-200 ease-in-out", {
               "rotate-180 transform": asc,
             })}
             onClick={() => updateFilter("order")}

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -117,8 +117,6 @@ export function EventFilterSidebar({
   const pathname = usePathname();
   const params = useSearchParams();
 
-  const inputRef = useRef(false);
-
   const filterSet =
     params.has("order") ||
     params.has("search") ||
@@ -141,17 +139,15 @@ export function EventFilterSidebar({
     const searchParams = new URLSearchParams(params);
     search ? searchParams.set("search", search) : searchParams.delete("search");
     router.push(`${pathname}?${searchParams}`, { scroll: false });
-    inputRef.current = false;
   }, 400);
 
   /**
    * This useEffect sets the search input to the value in the URL when the user navigates back, etc.
    */
+  const paramSearch = params.get("search") ?? "";
   useEffect(() => {
-    if (!inputRef.current) {
-      setSearchInput(params.get("search") ?? "");
-    }
-  }, [params]);
+    setSearchInput(paramSearch);
+  }, [paramSearch]);
 
   function updateFilter(element: string) {
     const searchParams = new URLSearchParams(params);
@@ -189,7 +185,6 @@ export function EventFilterSidebar({
             <Input
               value={searchInput}
               onChange={(e) => {
-                inputRef.current = true;
                 setSearchInput(e.target.value);
                 debouncedSearch(e.target.value);
               }}

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -274,12 +274,12 @@ export function EventFilterSidebar({
       <SidebarItem className="pt-6">
         <SidebarItemContent>
           <Label
-            className={cn("hoved:text-primary-hover cursor-pointer text-base text-primary", {
+            className={cn("cursor-pointer text-base text-primary hover:text-primary-hover", {
               invisible: !filterSet,
             })}
             onClick={() => resetFilter()}
           >
-            Nullstill alle
+            Nullstill alle filtere
           </Label>
         </SidebarItemContent>
       </SidebarItem>

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -53,7 +53,7 @@ export function EventFilter() {
   }
 
   return (
-    <div className="">
+    <div>
       <div className="flex flex-col border-b-2 border-solid border-opacity-20 pb-4 sm:flex-row sm:justify-between">
         <div className="flex flex-col items-center sm:flex-row sm:space-x-2">
           <Button

--- a/apps/web/src/components/event-filter.tsx
+++ b/apps/web/src/components/event-filter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { LuArrowDownNarrowWide as ArrowDownNarrowWide } from "react-icons/lu";
 import { useDebouncedCallback } from "use-debounce";


### PR DESCRIPTION
Noen oppdateringer til /arrangementer, hovedsakelig:

- Minimerer bruken av useEffect(), og gjør det mulig å navigere mellom tidligere states på filteret ved bruk av navigasjonsmulighetene i nettleseren.
- Legger til en knapp for å nullstille alle filtere
- Et par små style-changes
- Legger til et par kommentarer, og bruker noen tydligere variabelnavn
