### PR TITLE
Happening dashboard bugfixes

### DIFF
--- a/apps/web/src/app/(default)/dashbord/[slug]/page.tsx
+++ b/apps/web/src/app/(default)/dashbord/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function EventDashboard({ params }: Props) {
   const groups = await getStudentGroups();
 
   return (
-    <Container className="flex flex-col gap-10">
+    <Container layout="larger" className="flex flex-col gap-10 ">
       <div className="m-2">
         <Link href={`/${happeningType}/${happening.slug}`}>
           <span className="p-2">⇐</span>

--- a/apps/web/src/components/container.tsx
+++ b/apps/web/src/components/container.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/utils/cn";
 
 type ContainerProps = HTMLAttributes<HTMLDivElement> & {
   className?: string;
-  layout?: "normal" | "full";
+  layout?: "normal" | "larger" | "full";
   children: React.ReactNode;
 };
 
@@ -17,6 +17,7 @@ export const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
           "mx-auto flex w-full flex-col px-4 sm:px-6 lg:px-8",
           {
             "max-w-[1200px]": layout === "normal",
+            "max-w-[1500px]": layout === "larger",
             "max-w-full": layout === "full",
           },
           className,

--- a/apps/web/src/components/edit-registration-button.tsx
+++ b/apps/web/src/components/edit-registration-button.tsx
@@ -78,6 +78,7 @@ export function EditRegistrationButton({ id, registration }: EditRegistrationBut
       open={isOpen}
       onOpenChange={(newIsOpen) => {
         if (!newIsOpen) {
+          setIsOpen(false);
           form.reset();
         }
       }}

--- a/apps/web/src/components/edit-registration-button.tsx
+++ b/apps/web/src/components/edit-registration-button.tsx
@@ -25,6 +25,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { editRegistrationSchema, type editRegistrationForm } from "@/lib/schemas/editregistration";
+import { cn } from "@/utils/cn";
 
 type EditRegistrationButtonProps = {
   id: string;
@@ -119,54 +120,42 @@ export function EditRegistrationButton({ id, registration }: EditRegistrationBut
               <Label></Label>
             </div>
             <div className="grid w-full grid-cols-4 gap-1">
-              <button
-                className={`rounded-lg border px-2 py-4 text-center text-xs
-                ${
-                  selectedStatus === "registered"
-                    ? "border border-black bg-primary font-bold text-white"
-                    : "hover:bg-secondary"
-                }
-                  `}
+              <Button
+                variant={selectedStatus === "registered" ? "secondary" : "outline"}
+                className={cn("text-xs", {
+                  "border border-black": selectedStatus === "registered",
+                })}
                 onClick={() => handleStatusChange("registered")}
               >
                 Påmeldt
-              </button>
-              <button
-                className={`rounded-lg border px-2 py-4 text-center text-xs
-                  ${
-                    selectedStatus === "waiting"
-                      ? "border border-black bg-primary font-bold text-white"
-                      : "hover:bg-secondary"
-                  }
-                  `}
+              </Button>
+              <Button
+                variant={selectedStatus === "waiting" ? "secondary" : "outline"}
+                className={cn("text-xs", {
+                  "border border-black": selectedStatus === "waiting",
+                })}
                 onClick={() => handleStatusChange("waiting")}
               >
                 Venteliste
-              </button>
-              <button
-                className={`rounded-lg border px-2 py-4 text-center text-xs
-                  ${
-                    selectedStatus === "unregistered"
-                      ? "border border-black bg-primary font-bold text-white"
-                      : "hover:bg-secondary"
-                  }
-                `}
+              </Button>
+              <Button
+                variant={selectedStatus === "unregistered" ? "secondary" : "outline"}
+                className={cn("text-xs", {
+                  "border border-black": selectedStatus === "unregistered",
+                })}
                 onClick={() => handleStatusChange("unregistered")}
               >
                 Avmeldt
-              </button>
-              <button
-                className={`rounded-lg border px-2 py-4 text-center text-xs
-                  ${
-                    selectedStatus === "removed"
-                      ? "border border-black bg-primary font-bold text-white"
-                      : "hover:bg-secondary"
-                  }
-                `}
+              </Button>
+              <Button
+                variant={selectedStatus === "removed" ? "secondary" : "outline"}
+                className={cn("text-xs", {
+                  "border border-black": selectedStatus === "removed",
+                })}
                 onClick={() => handleStatusChange("removed")}
               >
                 Fjernet
-              </button>
+              </Button>
             </div>
             <div className="flex flex-col gap-5">
               <div className="flex flex-col gap-3">

--- a/apps/web/src/components/registration-table.tsx
+++ b/apps/web/src/components/registration-table.tsx
@@ -223,6 +223,10 @@ const RegistrationRow = ({
   const email = registration.user.alternativeEmail ?? registration.user.email ?? "";
   const id = registration.happeningId;
   const statusClass = getStatusClassColor(registration.status);
+  const reason =
+    registration.unregisterReason && registration.unregisterReason.length > 200
+      ? registration.unregisterReason.substring(0, 200) + "..."
+      : registration.unregisterReason;
 
   return (
     <tr
@@ -243,7 +247,7 @@ const RegistrationRow = ({
       <td className={`overflow-wrap px-6 py-4`}>
         <span className={`${statusClass}`}>{registrationStatusToString[registration.status]}</span>
       </td>
-      <td className="break-words px-6 py-4">{registration.unregisterReason}</td>
+      <td className="break-words px-6 py-4">{reason}</td>
       <td className="px-6 py-4">{registration.user.year}</td>
       <td className="overflow-wrap px-6 py-4">
         {registration.user.memberships.map((membership) => membership.group?.name).join(", ")}

--- a/apps/web/src/components/registration-table.tsx
+++ b/apps/web/src/components/registration-table.tsx
@@ -82,8 +82,8 @@ export function RegistrationTable({
   };
 
   return (
-    <div className="overflow-x-auto rounded-lg border shadow-md">
-      <div className="overflow-x-auto">
+    <div className="w-full overflow-y-auto rounded-lg border shadow-md">
+      <div className="overflow-y-auto">
         <div className="flex flex-col items-center gap-4 p-4 md:flex-row">
           <div className="flex w-full flex-col gap-1">
             <Label htmlFor="search">Søk:</Label>
@@ -162,8 +162,8 @@ export function RegistrationTable({
           </div>
         </div>
 
-        <div className="overflow-x-auto">
-          <table className="w-full table-auto text-left text-sm text-gray-500">
+        <div>
+          <table className="w-full table-fixed text-left text-sm text-gray-500">
             <thead className="bg-table-header-background text-xs uppercase text-table-header-foreground">
               <tr>
                 {showIndex && (
@@ -232,20 +232,20 @@ const RegistrationRow = ({
       })}
     >
       {showIndex && <td className="px-6 py-4">{index + 1}</td>}
-      <th scope="row" className="whitespace-nowrap px-6 py-4 font-medium">
+      <th scope="row" className=" overflow-wrap px-6 py-4 font-medium">
         {registration.user.name}
       </th>
-      <td className="px-6 py-4">
+      <td className="truncate px-6 py-4">
         <Link className="hover:underline" href={mailTo(email)}>
           {email}
         </Link>
       </td>
-      <td className={`px-6 py-4`}>
+      <td className={`overflow-wrap px-6 py-4`}>
         <span className={`${statusClass}`}>{registrationStatusToString[registration.status]}</span>
       </td>
-      <td className="px-6 py-4">{registration.unregisterReason}</td>
+      <td className="break-words px-6 py-4">{registration.unregisterReason}</td>
       <td className="px-6 py-4">{registration.user.year}</td>
-      <td className="px-6 py-4">
+      <td className="overflow-wrap px-6 py-4">
         {registration.user.memberships.map((membership) => membership.group?.name).join(", ")}
         {registration.user.memberships.length === 0 && "Ingen"}
       </td>


### PR DESCRIPTION
Et par bugfixes på happening dashboard:

- Krysset i hjørnet lukker Dialogen nå. Fix: Setter isOpen til false hvis onOpenChange er en lukke-operasjon.
- Øker widthen. Mye informasjon som skal få plass. Fjerner også horisontal scrolling og gjør at teksten wrapper vertikalt. Om reason er lengre enn 200 chars, så vises bare de 200 første.
- Knappene i formen har hatt default HTML type, som kan være buggy mtp. submit. Endrer til å bruke våre egne ui-buttons. 