### PR TITLE
Make new posts POP

### DIFF
--- a/apps/web/src/app/(default)/content.tsx
+++ b/apps/web/src/app/(default)/content.tsx
@@ -124,7 +124,7 @@ export async function Content() {
         <ul className="grid grid-cols-1 gap-x-3 gap-y-5 py-4">
           {posts.map((post) => (
             <li key={post._id}>
-              <PostPreview post={post} className="shadow-none" isFirst={post === posts[0]} />
+              <PostPreview post={post} className="shadow-none" />
             </li>
           ))}
         </ul>

--- a/apps/web/src/app/(default)/content.tsx
+++ b/apps/web/src/app/(default)/content.tsx
@@ -124,7 +124,7 @@ export async function Content() {
         <ul className="grid grid-cols-1 gap-x-3 gap-y-5 py-4">
           {posts.map((post) => (
             <li key={post._id}>
-              <PostPreview post={post} className="shadow-none" />
+              <PostPreview post={post} className="shadow-none" isFirst={post === posts[0]} />
             </li>
           ))}
         </ul>

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -15,7 +15,7 @@ type PostPreviewProps = {
 };
 
 export function PostPreview({ post, withBorder = false, className }: PostPreviewProps) {
-  const isNew = add(new Date(post._createdAt), { days: 2 }) > new Date();
+  const isNew = add(new Date(post._createdAt), { days: 3 }) > new Date();
 
   return (
     <Link href={`/for-studenter/innlegg/${post.slug}`}>

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -12,11 +12,10 @@ type PostPreviewProps = {
   post: Post;
   withBorder?: boolean;
   className?: string;
-  isFirst: boolean;
 };
 
-export function PostPreview({ post, withBorder = false, className, isFirst }: PostPreviewProps) {
-  const isNew = isFirst && add(new Date(post._createdAt), { days: 2 }) > new Date();
+export function PostPreview({ post, withBorder = false, className }: PostPreviewProps) {
+  const isNew = add(new Date(post._createdAt), { days: 2 }) > new Date();
 
   return (
     <Link href={`/for-studenter/innlegg/${post.slug}`}>
@@ -24,13 +23,11 @@ export function PostPreview({ post, withBorder = false, className, isFirst }: Po
         className={cn(
           "relative flex h-full flex-col gap-1 rounded-lg p-5 shadow-lg transition-colors duration-200 ease-in-out hover:bg-muted",
           withBorder && "border",
-          isNew && "bg-muted",
+          isNew && "bg-muted hover:bg-transparent",
           className,
         )}
       >
-        {isNew && (
-          <Chip className="absolute -top-1 left-2 animate-bounce bg-primary text-white">NY</Chip>
-        )}
+        {isNew && <Chip className="absolute -top-2 left-0 bg-primary text-white">NY</Chip>}
         <h3 className="line-clamp-2 flex gap-2 text-xl font-semibold md:text-2xl">{post.title}</h3>
 
         <p className="right-1 top-1 text-sm text-gray-500 sm:absolute">
@@ -42,7 +39,7 @@ export function PostPreview({ post, withBorder = false, className, isFirst }: Po
         <p className="my-2 line-clamp-2 italic">{removeMd(post.body)}</p>
 
         {post.authors && (
-          <div className="flex flex-row flex-wrap items-center gap-1 sm:absolute sm:-bottom-3 sm:left-4">
+          <div className="flex flex-row flex-wrap items-center gap-1 sm:absolute sm:-bottom-1 sm:right-4">
             {post.authors.map((author) => (
               <Chip className="bg-secondary text-secondary-foreground" key={author._id}>
                 {isBoard(author.name) ? "Hovedstyret" : author.name}

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { add, format } from "date-fns";
+import { addDays, format } from "date-fns";
 import { nb } from "date-fns/locale/nb";
 import removeMd from "remove-markdown";
 
@@ -15,7 +15,7 @@ type PostPreviewProps = {
 };
 
 export function PostPreview({ post, withBorder = false, className }: PostPreviewProps) {
-  const isNew = add(new Date(post._createdAt), { days: 3 }) > new Date();
+  const isNew = addDays(new Date(post._createdAt), 3) > new Date();
 
   return (
     <Link href={`/for-studenter/innlegg/${post.slug}`}>

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { format } from "date-fns";
+import { add, format } from "date-fns";
 import { nb } from "date-fns/locale/nb";
 import removeMd from "remove-markdown";
 
@@ -12,18 +12,25 @@ type PostPreviewProps = {
   post: Post;
   withBorder?: boolean;
   className?: string;
+  isFirst: boolean;
 };
 
-export function PostPreview({ post, withBorder = false, className }: PostPreviewProps) {
+export function PostPreview({ post, withBorder = false, className, isFirst }: PostPreviewProps) {
+  const isNew = isFirst && add(new Date(post._createdAt), { days: 2 }) > new Date();
+
   return (
     <Link href={`/for-studenter/innlegg/${post.slug}`}>
       <div
         className={cn(
           "relative flex h-full flex-col gap-1 rounded-lg p-5 shadow-lg transition-colors duration-200 ease-in-out hover:bg-muted",
           withBorder && "border",
+          isNew && "bg-muted",
           className,
         )}
       >
+        {isNew && (
+          <Chip className="absolute -top-1 left-2 animate-bounce bg-primary text-white">NY</Chip>
+        )}
         <h3 className="line-clamp-2 flex gap-2 text-xl font-semibold md:text-2xl">{post.title}</h3>
 
         <p className="right-1 top-1 text-sm text-gray-500 sm:absolute">


### PR DESCRIPTION
Tenker at flere får med seg nye innlegg dersom de er tydeligere markert. 

Derfor: om et innlegg er mindre enn 3 dager gammelt får det litt ekstra styling.
Kan potensielt forbedres med isRead eller noe lignende fra brukerens side (som det kanskje blir noe funksjonalitet rundt i det nye notifikasjonssystemet)