### PR TITLE
Kfalvestad/fix revalidation

### DIFF
--- a/apps/cms/schemas/index.ts
+++ b/apps/cms/schemas/index.ts
@@ -9,7 +9,7 @@ import spotRange from "./objects/spot-range";
 import post from "./post";
 import profile from "./profile";
 import staticInfo from "./static-info";
-import studentgroup from "./student-group";
+import studentGroup from "./student-group";
 
 export const schemaTypes = [
   happening,
@@ -19,7 +19,7 @@ export const schemaTypes = [
   profile,
   staticInfo,
   location,
-  studentgroup,
+  studentGroup,
   meetingMinute,
   spotRange,
   contactProfile,

--- a/apps/web/src/app/api/sanity/revalidate/route.ts
+++ b/apps/web/src/app/api/sanity/revalidate/route.ts
@@ -24,7 +24,7 @@ const revalidateTags = (tags: Array<string>) => {
  */
 export const POST = withBasicAuth(async (req) => {
   try {
-    const { type, slug } = (await req.json()) as {
+    const { type } = (await req.json()) as {
       operation: "create" | "update" | "delete";
       documentId: string;
       type: string;
@@ -54,13 +54,9 @@ export const POST = withBasicAuth(async (req) => {
     if (type === "studentGroup") {
       console.log("Revalidating student-groups");
       revalidateTags(["student-groups"]);
-      if (slug) {
-        console.log(`Revalidating student-group-${slug}`);
-        revalidateTags([`student-group-${slug}`]);
-      }
     }
 
-    return new Response(`Revalidated type: "${type}". Slug: "${slug}"`, {
+    return new Response(`Revalidated type: "${type}".`, {
       status: 200,
     });
   } catch (error) {

--- a/apps/web/src/sanity/student-group/requests.ts
+++ b/apps/web/src/sanity/student-group/requests.ts
@@ -28,7 +28,7 @@ export async function fetchStudentGroupBySlug(slug: string) {
       params: {
         slug,
       },
-      tags: [`student-group-${slug}`],
+      tags: [`student-groups`],
     }).then((res) => studentGroupSchema.parse(res));
   } catch {
     return null;


### PR DESCRIPTION
Mistenker at grunnen til at revalideringen av studentgrupper er uforutsigbar er at vi bruker to tags som behandler mye av den samme dataen. Mulig at det da skjer noe rart når vi revaliderer dem begge like etter hverandre? 

Here revaliderer jeg _alle_ studentgrupper nå ved oppdatering, for det skjer ikke så ofte uansett.
