### PR TITLE
Update db with strikes

### DIFF
--- a/packages/db/drizzle/migrations/0012_wide_vance_astro.sql
+++ b/packages/db/drizzle/migrations/0012_wide_vance_astro.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS "strike" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"strike_info_id" uuid NOT NULL,
+	"is_deleted" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "strike_info" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"happening_id" varchar(255) NOT NULL,
+	"issuer_id" text NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "is_banned" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "banned_from_strike" integer;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_idx" ON "strike" ("user_id","id");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "strike" ADD CONSTRAINT "strike_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "strike" ADD CONSTRAINT "strike_strike_info_id_strike_info_id_fk" FOREIGN KEY ("strike_info_id") REFERENCES "strike_info"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "strike_info" ADD CONSTRAINT "strike_info_happening_id_happening_id_fk" FOREIGN KEY ("happening_id") REFERENCES "happening"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "strike_info" ADD CONSTRAINT "strike_info_issuer_id_user_id_fk" FOREIGN KEY ("issuer_id") REFERENCES "user"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/drizzle/migrations/meta/0012_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1316 @@
+{
+  "id": "5e84880d-f0bf-405b-9d5c-c336616800c0",
+  "prevId": "b488748b-d6ae-4596-b745-24e98a1a1358",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_provider_account_id_pk": {
+          "name": "account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "answer": {
+      "name": "answer",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "answer_user_id_user_id_fk": {
+          "name": "answer_user_id_user_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "answer_happening_id_happening_id_fk": {
+          "name": "answer_happening_id_happening_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "answer_question_id_question_id_fk": {
+          "name": "answer_question_id_question_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "answer_user_id_happening_id_question_id_pk": {
+          "name": "answer_user_id_happening_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "happening_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "degree_id_pk": {
+          "name": "degree_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_id_pk": {
+          "name": "group_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "happenings_to_groups": {
+      "name": "happenings_to_groups",
+      "schema": "",
+      "columns": {
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "happenings_to_groups_happening_id_happening_id_fk": {
+          "name": "happenings_to_groups_happening_id_happening_id_fk",
+          "tableFrom": "happenings_to_groups",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "happenings_to_groups_group_id_group_id_fk": {
+          "name": "happenings_to_groups_group_id_group_id_fk",
+          "tableFrom": "happenings_to_groups",
+          "tableTo": "group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "happenings_to_groups_happening_id_group_id_pk": {
+          "name": "happenings_to_groups_happening_id_group_id_pk",
+          "columns": [
+            "happening_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "happening": {
+      "name": "happening",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "happening_type",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'event'"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_groups": {
+          "name": "registration_groups",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_groups": {
+          "name": "registration_start_groups",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "happening_id_pk": {
+          "name": "happening_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "happening_slug_unique": {
+          "name": "happening_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "question_type",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "options": {
+          "name": "options",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_happening_id_happening_id_fk": {
+          "name": "question_happening_id_happening_id_fk",
+          "tableFrom": "question",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_id_pk": {
+          "name": "question_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "react_to_key": {
+          "name": "react_to_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji_id": {
+          "name": "emoji_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reaction_user_id_user_id_fk": {
+          "name": "reaction_user_id_user_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reaction_react_to_key_emoji_id_user_id_pk": {
+          "name": "reaction_react_to_key_emoji_id_user_id_pk",
+          "columns": [
+            "react_to_key",
+            "emoji_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "registration": {
+      "name": "registration",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "unregister_reason": {
+          "name": "unregister_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_user_id_user_id_fk": {
+          "name": "registration_user_id_user_id_fk",
+          "tableFrom": "registration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "registration_happening_id_happening_id_fk": {
+          "name": "registration_happening_id_happening_id_fk",
+          "tableFrom": "registration",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "registration_user_id_happening_id_pk": {
+          "name": "registration_user_id_happening_id_pk",
+          "columns": [
+            "user_id",
+            "happening_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_session_token_pk": {
+          "name": "session_session_token_pk",
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "site_feedback": {
+      "name": "site_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "feedback_category",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "site_feedback_id_pk": {
+          "name": "site_feedback_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "spot_range": {
+      "name": "spot_range",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spots": {
+          "name": "spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_year": {
+          "name": "min_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_year": {
+          "name": "max_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spot_range_happening_id_happening_id_fk": {
+          "name": "spot_range_happening_id_happening_id_fk",
+          "tableFrom": "spot_range",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spot_range_id_pk": {
+          "name": "spot_range_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users_to_groups": {
+      "name": "users_to_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_groups_user_id_user_id_fk": {
+          "name": "users_to_groups_user_id_user_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_groups_group_id_group_id_fk": {
+          "name": "users_to_groups_group_id_group_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_groups_user_id_group_id_pk": {
+          "name": "users_to_groups_user_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_email": {
+          "name": "alternative_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_from_strike": {
+          "name": "banned_from_strike",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_degree_id_degree_id_fk": {
+          "name": "user_degree_id_degree_id_fk",
+          "tableFrom": "user",
+          "tableTo": "degree",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_id_pk": {
+          "name": "user_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "shopping_list_item": {
+      "name": "shopping_list_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shopping_list_item_user_id_user_id_fk": {
+          "name": "shopping_list_item_user_id_user_id_fk",
+          "tableFrom": "shopping_list_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_shopping_list_items": {
+      "name": "users_to_shopping_list_items",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_shopping_list_items_user_id_user_id_fk": {
+          "name": "users_to_shopping_list_items_user_id_user_id_fk",
+          "tableFrom": "users_to_shopping_list_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_shopping_list_items_item_id_shopping_list_item_id_fk": {
+          "name": "users_to_shopping_list_items_item_id_shopping_list_item_id_fk",
+          "tableFrom": "users_to_shopping_list_items",
+          "tableTo": "shopping_list_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_shopping_list_items_user_id_item_id_pk": {
+          "name": "users_to_shopping_list_items_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "whitelist": {
+      "name": "whitelist",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "whitelist_email_pk": {
+          "name": "whitelist_email_pk",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "strike": {
+      "name": "strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strike_info_id": {
+          "name": "strike_info_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "user_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "strike_user_id_user_id_fk": {
+          "name": "strike_user_id_user_id_fk",
+          "tableFrom": "strike",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "strike_strike_info_id_strike_info_id_fk": {
+          "name": "strike_strike_info_id_strike_info_id_fk",
+          "tableFrom": "strike",
+          "tableTo": "strike_info",
+          "columnsFrom": [
+            "strike_info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "strike_info": {
+      "name": "strike_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strike_info_happening_id_happening_id_fk": {
+          "name": "strike_info_happening_id_happening_id_fk",
+          "tableFrom": "strike_info",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "strike_info_issuer_id_user_id_fk": {
+          "name": "strike_info_issuer_id_user_id_fk",
+          "tableFrom": "strike_info",
+          "tableTo": "user",
+          "columnsFrom": [
+            "issuer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "degree_type": {
+      "name": "degree_type",
+      "values": {
+        "bachelors": "bachelors",
+        "masters": "masters",
+        "integrated": "integrated",
+        "year": "year"
+      }
+    },
+    "feedback_category": {
+      "name": "feedback_category",
+      "values": {
+        "bug": "bug",
+        "feature": "feature",
+        "login": "login",
+        "other": "other"
+      }
+    },
+    "happening_type": {
+      "name": "happening_type",
+      "values": {
+        "bedpres": "bedpres",
+        "event": "event",
+        "external": "external"
+      }
+    },
+    "question_type": {
+      "name": "question_type",
+      "values": {
+        "text": "text",
+        "textarea": "textarea",
+        "radio": "radio",
+        "checkbox": "checkbox"
+      }
+    },
+    "registration_status": {
+      "name": "registration_status",
+      "values": {
+        "registered": "registered",
+        "unregistered": "unregistered",
+        "removed": "removed",
+        "waiting": "waiting",
+        "pending": "pending"
+      }
+    },
+    "user_type": {
+      "name": "user_type",
+      "values": {
+        "student": "student",
+        "company": "company",
+        "guest": "guest",
+        "alum": "alum"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1706724154932,
       "tag": "0011_luxuriant_carmella_unuscione",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1708798994433,
+      "tag": "0012_wide_vance_astro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schemas/index.ts
+++ b/packages/db/schemas/index.ts
@@ -18,4 +18,4 @@ export * from "./shopping-list-items";
 export * from "./users-to-shopping-list-items";
 export * from "./whitelist";
 export * from "./strikes";
-export * from "./strike-info";
+export * from "./strike-infos";

--- a/packages/db/schemas/index.ts
+++ b/packages/db/schemas/index.ts
@@ -17,3 +17,5 @@ export * from "./verification-tokens";
 export * from "./shopping-list-items";
 export * from "./users-to-shopping-list-items";
 export * from "./whitelist";
+export * from "./strikes";
+export * from "./strike-info";

--- a/packages/db/schemas/strike-info.ts
+++ b/packages/db/schemas/strike-info.ts
@@ -1,0 +1,34 @@
+import { relations } from "drizzle-orm";
+import { pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+
+import { happenings, users } from ".";
+
+export const strikeInfo = pgTable("strikeInfo", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  happeningId: varchar("happening-id", { length: 255 })
+    .notNull()
+    .references(() => happenings.id),
+  issuerId: text("reporter-id")
+    .notNull()
+    .references(() => users.id),
+  reason: text("reason").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const strikeInfoRelations = relations(strikeInfo, ({ one }) => ({
+  issuer: one(users, {
+    fields: [strikeInfo.issuerId],
+    references: [users.id],
+  }),
+  happening: one(happenings, {
+    fields: [strikeInfo.happeningId],
+    references: [happenings.id],
+  }),
+}));
+
+export type StrikeInfo = (typeof strikeInfo)["$inferSelect"];
+export type StrikeInfoInsert = (typeof strikeInfo)["$inferInsert"];
+
+export const selectStrikeInfoSchema = createSelectSchema(strikeInfo);
+export const insertStrikeInfoSchema = createInsertSchema(strikeInfo);

--- a/packages/db/schemas/strike-infos.ts
+++ b/packages/db/schemas/strike-infos.ts
@@ -4,31 +4,31 @@ import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 import { happenings, users } from ".";
 
-export const strikeInfo = pgTable("strikeInfo", {
+export const strikeInfos = pgTable("strike_info", {
   id: uuid("id").defaultRandom().primaryKey(),
-  happeningId: varchar("happening-id", { length: 255 })
+  happeningId: varchar("happening_id", { length: 255 })
     .notNull()
     .references(() => happenings.id),
-  issuerId: text("reporter-id")
+  issuerId: text("issuer_id")
     .notNull()
     .references(() => users.id),
   reason: text("reason").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 
-export const strikeInfoRelations = relations(strikeInfo, ({ one }) => ({
+export const strikeInfoRelations = relations(strikeInfos, ({ one }) => ({
   issuer: one(users, {
-    fields: [strikeInfo.issuerId],
+    fields: [strikeInfos.issuerId],
     references: [users.id],
   }),
   happening: one(happenings, {
-    fields: [strikeInfo.happeningId],
+    fields: [strikeInfos.happeningId],
     references: [happenings.id],
   }),
 }));
 
-export type StrikeInfo = (typeof strikeInfo)["$inferSelect"];
-export type StrikeInfoInsert = (typeof strikeInfo)["$inferInsert"];
+export type StrikeInfo = (typeof strikeInfos)["$inferSelect"];
+export type StrikeInfoInsert = (typeof strikeInfos)["$inferInsert"];
 
-export const selectStrikeInfoSchema = createSelectSchema(strikeInfo);
-export const insertStrikeInfoSchema = createInsertSchema(strikeInfo);
+export const selectStrikeInfoSchema = createSelectSchema(strikeInfos);
+export const insertStrikeInfoSchema = createInsertSchema(strikeInfos);

--- a/packages/db/schemas/strikes.ts
+++ b/packages/db/schemas/strikes.ts
@@ -1,0 +1,33 @@
+import { relations } from "drizzle-orm";
+import { boolean, pgTable, serial, text, uuid } from "drizzle-orm/pg-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+
+import { strikeInfo, users } from ".";
+
+export const strikes = pgTable("strike", {
+  id: serial("id").notNull().primaryKey(),
+  userId: text("user-id")
+    .notNull()
+    .references(() => users.id),
+  strikeInfoId: uuid("info")
+    .notNull()
+    .references(() => strikeInfo.id, { onDelete: "cascade" }),
+  isDeleted: boolean("isDeleted").default(false),
+});
+
+export const strikesRelations = relations(strikes, ({ one }) => ({
+  user: one(users, {
+    fields: [strikes.userId],
+    references: [users.id],
+  }),
+  strikeInfo: one(strikeInfo, {
+    fields: [strikes.strikeInfoId],
+    references: [strikeInfo.id],
+  }),
+}));
+
+export type Strike = (typeof strikes)["$inferSelect"];
+export type StrikeInsert = (typeof strikes)["$inferInsert"];
+
+export const selectStrikeSchema = createSelectSchema(strikes);
+export const insertStrikeSchema = createInsertSchema(strikes);

--- a/packages/db/schemas/strikes.ts
+++ b/packages/db/schemas/strikes.ts
@@ -2,26 +2,24 @@ import { relations } from "drizzle-orm";
 import { boolean, index, pgTable, serial, text, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
-import { strikeInfo, users } from ".";
+import { strikeInfos, users } from ".";
 
 export const strikes = pgTable(
   "strike",
   {
     id: serial("id").notNull().primaryKey(),
-    userId: text("user-id")
+    userId: text("user_id")
       .notNull()
       .references(() => users.id),
-    strikeInfoId: uuid("info")
+    strikeInfoId: uuid("strike_info_id")
       .notNull()
-      .references(() => strikeInfo.id, { onDelete: "cascade" }),
-    isBannable: boolean("isBannable").notNull().default(false),
-    isDeleted: boolean("isDeleted").notNull().default(false),
+      .references(() => strikeInfos.id, { onDelete: "cascade" }),
+    isBannable: boolean("is_bannable").notNull().default(false),
+    isDeleted: boolean("is_deleted").notNull().default(false),
   },
-  (table) => {
-    return {
-      userIdx: index("userIdx").on(table.userId, table.id),
-    };
-  },
+  (table) => ({
+    userIdx: index("user_idx").on(table.userId, table.id),
+  }),
 );
 
 export const strikesRelations = relations(strikes, ({ one }) => ({
@@ -29,9 +27,9 @@ export const strikesRelations = relations(strikes, ({ one }) => ({
     fields: [strikes.userId],
     references: [users.id],
   }),
-  strikeInfo: one(strikeInfo, {
+  strikeInfo: one(strikeInfos, {
     fields: [strikes.strikeInfoId],
-    references: [strikeInfo.id],
+    references: [strikeInfos.id],
   }),
 }));
 

--- a/packages/db/schemas/strikes.ts
+++ b/packages/db/schemas/strikes.ts
@@ -14,7 +14,6 @@ export const strikes = pgTable(
     strikeInfoId: uuid("strike_info_id")
       .notNull()
       .references(() => strikeInfos.id, { onDelete: "cascade" }),
-    isBannable: boolean("is_bannable").notNull().default(false),
     isDeleted: boolean("is_deleted").notNull().default(false),
   },
   (table) => ({

--- a/packages/db/schemas/strikes.ts
+++ b/packages/db/schemas/strikes.ts
@@ -1,19 +1,31 @@
-import { relations } from "drizzle-orm";
-import { boolean, pgTable, serial, text, uuid } from "drizzle-orm/pg-core";
+import { eq, relations } from "drizzle-orm";
+import { boolean, index, pgTable, serial, text, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 import { strikeInfo, users } from ".";
 
-export const strikes = pgTable("strike", {
-  id: serial("id").notNull().primaryKey(),
-  userId: text("user-id")
-    .notNull()
-    .references(() => users.id),
-  strikeInfoId: uuid("info")
-    .notNull()
-    .references(() => strikeInfo.id, { onDelete: "cascade" }),
-  isDeleted: boolean("isDeleted").default(false),
-});
+export const strikes = pgTable(
+  "strike",
+  {
+    id: serial("id").notNull().primaryKey(),
+    userId: text("user-id")
+      .notNull()
+      .references(() => users.id),
+    strikeInfoId: uuid("info")
+      .notNull()
+      .references(() => strikeInfo.id, { onDelete: "cascade" }),
+    isBannable: boolean("isBannable").notNull().default(false),
+    isDeleted: boolean("isDeleted").notNull().default(false),
+  },
+  (table) => {
+    return {
+      bannableIdx: index("bannableIdx")
+        .on(table.userId, table.id)
+        .desc()
+        .where(eq(table.isBannable, true)),
+    };
+  },
+);
 
 export const strikesRelations = relations(strikes, ({ one }) => ({
   user: one(users, {

--- a/packages/db/schemas/strikes.ts
+++ b/packages/db/schemas/strikes.ts
@@ -1,4 +1,4 @@
-import { eq, relations } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import { boolean, index, pgTable, serial, text, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
@@ -19,10 +19,7 @@ export const strikes = pgTable(
   },
   (table) => {
     return {
-      bannableIdx: index("bannableIdx")
-        .on(table.userId, table.id)
-        .desc()
-        .where(eq(table.isBannable, true)),
+      userIdx: index("userIdx").on(table.userId, table.id),
     };
   },
 );

--- a/packages/db/schemas/users.ts
+++ b/packages/db/schemas/users.ts
@@ -25,6 +25,7 @@ export const users = pgTable(
     year: integer("year"),
     type: userTypeEnum("type").notNull().default("student"),
     isBanned: boolean("is_banned").notNull().default(false),
+    bannedFromStrike: integer("banned_from_strike"),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.id] }),
@@ -39,6 +40,10 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   memberships: many(usersToGroups),
   likes: many(usersToShoppingListItems),
   strikes: many(strikes),
+  bannedFromStrike: one(strikes, {
+    fields: [users.bannedFromStrike],
+    references: [strikes.id],
+  }),
 }));
 
 export type User = (typeof users)["$inferSelect"];

--- a/packages/db/schemas/users.ts
+++ b/packages/db/schemas/users.ts
@@ -25,7 +25,6 @@ export const users = pgTable(
     year: integer("year"),
     type: userTypeEnum("type").notNull().default("student"),
     isBanned: boolean("is_banned").notNull().default(false),
-    bannedFromStrike: integer("strike_id"),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.id] }),
@@ -40,10 +39,6 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   memberships: many(usersToGroups),
   likes: many(usersToShoppingListItems),
   strikes: many(strikes),
-  bannedFromStrike: one(strikes, {
-    fields: [users.bannedFromStrike],
-    references: [strikes.id],
-  }),
 }));
 
 export type User = (typeof users)["$inferSelect"];

--- a/packages/db/schemas/users.ts
+++ b/packages/db/schemas/users.ts
@@ -1,8 +1,16 @@
 import { relations } from "drizzle-orm";
-import { integer, pgTable, primaryKey, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
-import { degrees, usersToGroups, usersToShoppingListItems, userTypeEnum } from ".";
+import { degrees, strikes, usersToGroups, usersToShoppingListItems, userTypeEnum } from ".";
 
 export const users = pgTable(
   "user",
@@ -16,6 +24,8 @@ export const users = pgTable(
     degreeId: varchar("degree_id", { length: 255 }).references(() => degrees.id),
     year: integer("year"),
     type: userTypeEnum("type").notNull().default("student"),
+    isBanned: boolean("is_banned").notNull().default(false),
+    bannedFromStrike: integer("strike_id"),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.id] }),
@@ -29,6 +39,11 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   }),
   memberships: many(usersToGroups),
   likes: many(usersToShoppingListItems),
+  strikes: many(strikes),
+  bannedFromStrike: one(strikes, {
+    fields: [users.bannedFromStrike],
+    references: [strikes.id],
+  }),
 }));
 
 export type User = (typeof users)["$inferSelect"];


### PR DESCRIPTION
Oppdaterer DBen for å klargjøre for prikkesystemet. 

To nye tabeller:

- **strikes**: én rad utgjør én prikk
- **strike-info**: gir informasjon om prikkene. Egen tabell slik at informasjonen kan gjenbrukes dersom det gis flere prikker på en gang.