### PR TITLE
sort event dashboard by createdAt

### DIFF
--- a/apps/web/src/app/(default)/dashbord/[slug]/page.tsx
+++ b/apps/web/src/app/(default)/dashbord/[slug]/page.tsx
@@ -65,6 +65,9 @@ export default async function EventDashboard({ params }: Props) {
       removed: 3,
       pending: 4,
     };
+    if (a.status === b.status) {
+      return a.createdAt.getTime() - b.createdAt.getTime();
+    }
 
     return statusOrder[a.status] - statusOrder[b.status];
   });


### PR DESCRIPTION
Event dashbord var ikke sortert på påmeldingstid. Bruker createdAt og ignorerer changedStatusAt
