### PR TITLE
Add auth check in page

### DIFF
--- a/apps/web/src/app/(admin)/admin/brukere/page.tsx
+++ b/apps/web/src/app/(admin)/admin/brukere/page.tsx
@@ -21,6 +21,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { getAllUsers } from "@/data/users/queries";
+import { ensureWebkom } from "@/lib/ensure";
 import { UserForm } from "./user-form";
 
 export const dynamic = "force-dynamic";
@@ -28,6 +29,8 @@ export const dynamic = "force-dynamic";
 export type AllUsers = Awaited<ReturnType<typeof getAllUsers>>;
 
 export default async function UsersOverview() {
+  await ensureWebkom();
+
   const [users, groups] = await Promise.all([getAllUsers(), db.query.groups.findMany()]);
 
   return (

--- a/apps/web/src/app/(admin)/admin/grupper/page.tsx
+++ b/apps/web/src/app/(admin)/admin/grupper/page.tsx
@@ -20,11 +20,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ensureWebkom } from "@/lib/ensure";
 import { MembersModal } from "./members-modal";
 
-export const dynamic = "force-dynamic";
-
 export default async function AdminGroupsPage() {
+  await ensureWebkom();
+
   const groups = await db.query.groups.findMany({
     with: {
       members: {

--- a/apps/web/src/app/(admin)/admin/happenings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/happenings/page.tsx
@@ -2,10 +2,13 @@ import { db } from "@echo-webkom/db";
 
 import { Container } from "@/components/container";
 import { Heading } from "@/components/typography/heading";
+import { ensureWebkom } from "@/lib/ensure";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminHappeningsPage() {
+  await ensureWebkom();
+
   const happenings = await db.query.happenings.findMany({
     columns: {
       slug: true,

--- a/apps/web/src/app/(admin)/admin/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/layout.tsx
@@ -1,12 +1,9 @@
-import { redirect } from "next/navigation";
 import { type Metadata } from "next/types";
-
-import { auth } from "@echo-webkom/auth";
 
 import { Footer } from "@/components/footer";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { SiteHeader } from "@/components/site-header";
-import { isWebkom } from "@/lib/memberships";
+import { ensureWebkom } from "@/lib/ensure";
 
 type Props = {
   children: React.ReactNode;
@@ -48,11 +45,7 @@ const adminRoutes = [
 ];
 
 export default async function AdminDashboardLayout({ children }: Props) {
-  const user = await auth();
-
-  if (!user || !isWebkom(user)) {
-    return redirect("/");
-  }
+  await ensureWebkom();
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -6,7 +6,7 @@ export default function Dashboard() {
     <Container>
       <Heading className="mb-4">Dashboard</Heading>
 
-      <p>Velkommen til dashboardet. Bla blab blabblalb bal</p>
+      <p>Velkommen til dashboardet.</p>
     </Container>
   );
 }

--- a/apps/web/src/app/(admin)/admin/studieretninger/page.tsx
+++ b/apps/web/src/app/(admin)/admin/studieretninger/page.tsx
@@ -9,10 +9,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { getAllDegrees } from "@/data/degrees/queries";
+import { ensureWebkom } from "@/lib/ensure";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminDegreePage() {
+  await ensureWebkom();
   const degrees = await getAllDegrees();
 
   return (

--- a/apps/web/src/app/(admin)/admin/tilbakemeldinger/page.tsx
+++ b/apps/web/src/app/(admin)/admin/tilbakemeldinger/page.tsx
@@ -3,9 +3,11 @@ import { type SiteFeedback } from "@echo-webkom/db/schemas";
 import { Container } from "@/components/container";
 import { Heading } from "@/components/typography/heading";
 import { getAllFeedback } from "@/data/site-feedbacks/queries";
+import { ensureWebkom } from "@/lib/ensure";
 import { shortDate } from "@/utils/date";
 
 export default async function FeedbackOverview() {
+  await ensureWebkom();
   const feedback = await getAllFeedback();
 
   return (

--- a/apps/web/src/app/(admin)/admin/whitelist/page.tsx
+++ b/apps/web/src/app/(admin)/admin/whitelist/page.tsx
@@ -12,11 +12,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import WhitelistButton from "@/components/whitelist-button";
+import { ensureWebkom } from "@/lib/ensure";
 import { shortDateNoTime } from "@/utils/date";
 
-export const dynamic = "force-dynamic";
-
 export default async function WhitelistPage() {
+  await ensureWebkom();
   const whitelisted = await db.query.whitelist.findMany();
 
   return (

--- a/apps/web/src/lib/ensure.ts
+++ b/apps/web/src/lib/ensure.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { redirect } from "next/navigation";
 
 import { auth } from "@echo-webkom/auth";

--- a/apps/web/src/lib/ensure.ts
+++ b/apps/web/src/lib/ensure.ts
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "@echo-webkom/auth";
+
+import { isMemberOf } from "./memberships";
+
+export const ensureUser = async (groups?: Array<string>) => {
+  const user = await auth();
+
+  if (!user) {
+    return redirect("/");
+  }
+
+  if (groups && !isMemberOf(user, groups)) {
+    return redirect("/");
+  }
+
+  return user;
+};
+
+export const ensureWebkom = async () => ensureUser(["webkom"]);


### PR DESCRIPTION
Flyttet auth check i hver admin route. Det er tydligvis bad practice å bruke layout som middleware, data kan fortsatt potensielt lekkes. Så lagde en søk hjelpe-funksjon for å `ensure` at noen er logget inn.
