### PR TITLE
Optimize reg count

### DIFF
--- a/apps/web/src/app/(default)/_components/happening-preview.tsx
+++ b/apps/web/src/app/(default)/_components/happening-preview.tsx
@@ -1,54 +1,24 @@
+import { Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { isFuture, isToday } from "date-fns";
 import { RxCalendar } from "react-icons/rx";
 
-import { type Registration } from "@echo-webkom/db/schemas";
 import { urlFor } from "@echo-webkom/sanity";
 
-import { getRegistrationsByHappeningId } from "@/data/registrations/queries";
-import { getSpotRangeByHappeningId } from "@/data/spotrange/queries";
+import { getHappeningSpotRangeAndRegistrations } from "@/data/happenings/queries";
 import { createHappeningLink } from "@/lib/create-link";
 import { isBedpres } from "@/lib/is-bedpres";
+import { getSpotRangeInfo } from "@/lib/spot-range-info";
 import { type fetchHomeHappenings } from "@/sanity/happening";
-import { cn } from "@/utils/cn";
 import { shortDateNoTimeNoYear, shortDateNoYear, time } from "@/utils/date";
 
-const getSpotRangeInfo = <TSpotRange extends { spots: number; minYear: number; maxYear: number }>(
-  spotRanges: Array<TSpotRange>,
-  registrations: Array<Registration>,
-) => {
-  const maxCapacity = spotRanges.reduce((acc, curr) => acc + curr.spots, 0);
-  const registeredCount = registrations.filter(
-    (registration) => registration.status === "registered",
-  ).length;
-  const waitingListCount = registrations.filter(
-    (registration) => registration.status === "waiting",
-  ).length;
-
-  return {
-    maxCapacity,
-    registeredCount,
-    waitingListCount,
-  };
-};
-
-export async function HappeningPreview({
+export function HappeningPreview({
   happening,
 }: {
   happening: Awaited<ReturnType<typeof fetchHomeHappenings>>[number];
 }) {
   const href = createHappeningLink(happening);
-
-  const [registrations, spotRange] = await Promise.all([
-    getRegistrationsByHappeningId(happening._id),
-    getSpotRangeByHappeningId(happening._id),
-  ]);
-
-  const { maxCapacity, registeredCount, waitingListCount } = getSpotRangeInfo(
-    spotRange ?? [],
-    registrations,
-  );
 
   return (
     <Link href={href}>
@@ -86,25 +56,28 @@ export async function HappeningPreview({
               <time>{shortDateNoTimeNoYear(happening.date)}</time>
             </li>
             <li>
-              <span className="tracking-wider">
-                {happening.registrationStart &&
-                  maxCapacity > 0 &&
-                  (isFuture(new Date(happening.registrationStart)) ? (
-                    maxCapacity + " plasser"
-                  ) : (
-                    <p>
-                      {cn(
-                        registeredCount + waitingListCount >= maxCapacity
-                          ? "Fullt"
-                          : `${registeredCount}/${maxCapacity}` || ("Uendelig" && "∞"),
-                      )}
-                    </p>
-                  ))}
-              </span>
+              <Suspense fallback={<div className="flex-none" />}>
+                <HappeningRegistrationInfo happening={happening} />
+              </Suspense>
             </li>
           </ul>
         </div>
       </div>
     </Link>
   );
+}
+
+async function HappeningRegistrationInfo({
+  happening,
+}: {
+  happening: Awaited<ReturnType<typeof fetchHomeHappenings>>[number];
+}) {
+  const { spotRanges, registrations } = await getHappeningSpotRangeAndRegistrations(happening._id);
+  const info = getSpotRangeInfo(happening, spotRanges, registrations);
+
+  if (!info) {
+    return null;
+  }
+
+  return <p>{info}</p>;
 }

--- a/apps/web/src/app/(default)/page.tsx
+++ b/apps/web/src/app/(default)/page.tsx
@@ -8,15 +8,12 @@ import { HyggkomShoppingList } from "@/components/hyggkom-shopping-list";
 import { JobAdPreview } from "@/components/job-ad-preview";
 import MovieClubCard from "@/components/movie-club-card";
 import { PostPreview } from "@/components/post-preview";
+import { NUM_HAPPENINGS } from "@/config";
 import { getAllShoppinglistItems } from "@/data/shopping-list-item/queries";
 import { fetchHomeHappenings } from "@/sanity/happening";
 import { fetchAvailableJobAds } from "@/sanity/job-ad";
 import { fetchPosts } from "@/sanity/posts";
 import { HappeningPreview } from "./_components/happening-preview";
-
-const NUM_HAPPENINGS = !isNaN(Number(process.env.NUM_HAPPENINGS))
-  ? Number(process.env.NUM_HAPPENINGS)
-  : 4;
 
 export default async function HomePage() {
   const authData = auth();

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -17,3 +17,7 @@ export const PROFILE_IMAGE_FUNCTION_URL = "https://echo-images.azurewebsites.net
 export const COOKIE_BANNER = "cookie-banner";
 
 export const BOOMTOWN_HOSTNAME = process.env.NEXT_PUBLIC_BOOMTOWN_HOSTNAME;
+
+export const NUM_HAPPENINGS = !isNaN(Number(process.env.NUM_HAPPENINGS))
+  ? Number(process.env.NUM_HAPPENINGS)
+  : 4;

--- a/apps/web/src/data/happenings/queries.ts
+++ b/apps/web/src/data/happenings/queries.ts
@@ -2,7 +2,15 @@ import { and, asc, eq, gt, lt } from "drizzle-orm";
 import { log } from "next-axiom";
 
 import { db } from "@echo-webkom/db";
-import { type Happening, type HappeningType } from "@echo-webkom/db/schemas";
+import {
+  happenings,
+  registrations,
+  spotRanges,
+  type Happening,
+  type HappeningType,
+  type Registration,
+  type SpotRange,
+} from "@echo-webkom/db/schemas";
 
 import { isErrorMessage } from "@/utils/error";
 
@@ -48,6 +56,36 @@ export async function getHappeningById(id: string) {
 
       return null;
     });
+}
+
+export async function getHappeningSpotRangeAndRegistrations(happeningId: string) {
+  const result = await db
+    .select()
+    .from(happenings)
+    .leftJoin(spotRanges, eq(spotRanges.happeningId, happeningId))
+    .leftJoin(registrations, eq(registrations.happeningId, happeningId))
+    .where(eq(happenings.id, happeningId));
+
+  return result.reduce(
+    (acc, curr) => {
+      if (curr.spot_range) {
+        acc.spotRanges.push(curr.spot_range);
+      }
+
+      if (curr.registration) {
+        acc.registrations.push(curr.registration);
+      }
+
+      return acc;
+    },
+    {
+      spotRanges: [],
+      registrations: [],
+    } as {
+      spotRanges: Array<SpotRange>;
+      registrations: Array<Registration>;
+    },
+  );
 }
 
 export async function getHappeningsFromDate(date: Date, type: HappeningType) {

--- a/apps/web/src/data/spotrange/queries.ts
+++ b/apps/web/src/data/spotrange/queries.ts
@@ -1,5 +1,4 @@
 import { unstable_cache as cache } from "next/cache";
-import { eq } from "drizzle-orm";
 import { log } from "next-axiom";
 
 import { db } from "@echo-webkom/db";
@@ -11,7 +10,7 @@ export async function getSpotRangeByHappeningId(happeningId: string) {
     async () => {
       return await db.query.spotRanges
         .findMany({
-          where: (spotRange) => eq(spotRange.happeningId, happeningId),
+          where: (spotRange, { eq }) => eq(spotRange.happeningId, happeningId),
         })
         .catch(() => {
           log.error("Failed to fetch spot range", {

--- a/apps/web/src/lib/__tests__/get-spot-range-info.test.ts
+++ b/apps/web/src/lib/__tests__/get-spot-range-info.test.ts
@@ -1,0 +1,56 @@
+import { addDays } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import { type RegistrationStatus } from "@echo-webkom/db/schemas";
+
+import { getSpotRangeInfo } from "../spot-range-info";
+
+const TODAY = new Date();
+const TOMORROW = addDays(TODAY, 1).toISOString();
+const YESTERDAY = addDays(TODAY, -1).toISOString();
+
+describe("getSpotRangeInfo", () => {
+  it("should return displays spots", () => {
+    const happening = { registrationStart: TOMORROW };
+    const spotRanges = [{ spots: 60 }];
+    const registrations = [
+      { status: "registered" },
+      { status: "registered" },
+      { status: "waiting" },
+    ] satisfies Array<{ status: RegistrationStatus }>;
+
+    expect(getSpotRangeInfo(happening, spotRanges, registrations)).toBe("60 plasser");
+  });
+
+  it("should return 'Fullt' when full", () => {
+    const happening = { registrationStart: YESTERDAY };
+    const spotRanges = [{ spots: 3 }];
+    const registrations = [
+      { status: "registered" },
+      { status: "registered" },
+      { status: "registered" },
+    ] satisfies Array<{ status: RegistrationStatus }>;
+
+    expect(getSpotRangeInfo(happening, spotRanges, registrations)).toBe("Fullt");
+  });
+
+  it("should display nothing", () => {
+    const happening = { registrationStart: TOMORROW };
+    const spotRanges: Array<never> = [];
+    const registrations = [] satisfies Array<{ status: RegistrationStatus }>;
+
+    expect(getSpotRangeInfo(happening, spotRanges, registrations)).toBe(null);
+  });
+
+  it("should display '∞' when max capacity is 0", () => {
+    const happening = { registrationStart: YESTERDAY };
+    const spotRanges = [{ spots: 0 }];
+    const registrations = [
+      {
+        status: "registered",
+      },
+    ] satisfies Array<{ status: RegistrationStatus }>;
+
+    expect(getSpotRangeInfo(happening, spotRanges, registrations)).toBe("1/∞");
+  });
+});

--- a/apps/web/src/lib/spot-range-info.ts
+++ b/apps/web/src/lib/spot-range-info.ts
@@ -1,0 +1,35 @@
+import { isFuture } from "date-fns";
+
+import { type RegistrationStatus } from "@echo-webkom/db/schemas";
+
+const INFINITY = "∞";
+
+export function getSpotRangeInfo<
+  H extends { registrationStart?: string },
+  S extends { spots: number },
+  R extends { status: RegistrationStatus },
+>(happening: H, spotRanges: Array<S>, registrations: Array<R>) {
+  const maxCapacity = spotRanges.reduce((acc, curr) => acc + curr.spots, 0);
+  const registeredCount = registrations.filter(
+    (registration) => registration.status === "registered",
+  ).length;
+  const waitingListCount = registrations.filter(
+    (registration) => registration.status === "waiting",
+  ).length;
+
+  const actualCapacity = maxCapacity === 0 ? INFINITY : maxCapacity;
+
+  if (!happening.registrationStart || spotRanges.length === 0) {
+    return null;
+  }
+
+  if (isFuture(new Date(happening.registrationStart))) {
+    return `${actualCapacity} plasser`;
+  }
+
+  if (actualCapacity !== INFINITY && registeredCount + waitingListCount >= maxCapacity) {
+    return "Fullt";
+  }
+
+  return `${registeredCount}/${actualCapacity}`;
+}

--- a/packages/db/schemas/spot-ranges.ts
+++ b/packages/db/schemas/spot-ranges.ts
@@ -26,7 +26,7 @@ export const spotRanges = pgTable(
 );
 
 export const spotRangesRelations = relations(spotRanges, ({ one }) => ({
-  event: one(happenings, {
+  happening: one(happenings, {
     fields: [spotRanges.happeningId],
     references: [happenings.id],
   }),


### PR DESCRIPTION
Nå burde ikke det å hente antall påmeldte på et arrangement blocke hele siden. Altså vi kan fortsatt sende siden til brukeren selv om db queries ikke er ferdig.

Gjorde også om litt på `getSpotRangeInfo`. Nå gir den oss ikke `maxCapacity`, `registeredCount` og `waitingListCount`, men heller en `string` som er fra de verdeiene. Gjør det litt lettere å unit-teste?

## Hvorfor?

Grunnen til at jeg gjør dette er fordi alle sidene våres er egentlig ganske raske, uten om forsiden. Jeg mistenker at dette kanskje kan være hvorfor.

Tabellen under hvis hvor lang tid `/` bruker i forhold til andre routes på siden.

<table>
<tr>
 <td>Path
 <td>Min Duration (ms)
 <td>Avg Duration (ms)
 <td>Max Duration (ms)
<tr>
 <td>Forsiden
 <td>153
 <td>611
 <td>2000 (2 sec)
<tr>
 <td>Alle andre sider
 <td>7
 <td>30
 <td>200
</table>

Det kan også hende at det må mere til for å gjøre forsiden raskere, men sjekker dette først.
