### PR TITLE
Add comments to events

### DIFF
--- a/apps/web/src/app/(default)/arrangement/[slug]/page.tsx
+++ b/apps/web/src/app/(default)/arrangement/[slug]/page.tsx
@@ -1,15 +1,9 @@
 import { cache } from "react";
-import Image from "next/image";
 import { notFound } from "next/navigation";
 import { log } from "next-axiom";
 
-import { Container } from "@/components/container";
-import { HappeningSidebar } from "@/components/happening-sidebar";
-import { Markdown } from "@/components/markdown";
-import { Heading } from "@/components/typography/heading";
-import { Text } from "@/components/typography/text";
+import { EventPage } from "@/components/event-page";
 import { fetchHappeningBySlug } from "@/sanity/happening/requests";
-import { shortDate } from "@/utils/date";
 
 type Props = {
   params: {
@@ -38,43 +32,8 @@ export async function generateMetadata({ params }: Props) {
   };
 }
 
-export default async function EventPage({ params }: Props) {
+export default async function EventPage_({ params }: Props) {
   const event = await getData(params.slug);
 
-  return (
-    <Container className="w-full py-10 md:max-w-[700px] lg:max-w-[1500px]">
-      <div className="flex flex-col gap-8 lg:flex-row">
-        <HappeningSidebar event={event} />
-
-        {/* Content */}
-        <article className="w-full">
-          <Heading>{event.title}</Heading>
-
-          {event.body ? (
-            <Markdown content={event.body} />
-          ) : (
-            <div className="mx-auto flex w-fit flex-col gap-8 p-5">
-              <h3 className="text-center text-xl font-medium">Mer informasjon kommer!</h3>
-              <Image
-                className="rounded-lg"
-                src="/gif/wallace-construction.gif"
-                alt="Wallace hammering"
-                width={400}
-                height={400}
-              />
-            </div>
-          )}
-        </article>
-      </div>
-
-      <div className="pt-10 text-center text-muted-foreground lg:mt-auto">
-        <Text size="sm" className="p-0">
-          Publisert: {shortDate(event._createdAt)}
-        </Text>
-        <Text size="sm" className="p-0">
-          Sist oppdatert: {shortDate(event._updatedAt)}
-        </Text>
-      </div>
-    </Container>
-  );
+  return <EventPage event={event} />;
 }

--- a/apps/web/src/app/(default)/bedpres/[slug]/page.tsx
+++ b/apps/web/src/app/(default)/bedpres/[slug]/page.tsx
@@ -1,15 +1,9 @@
 import { cache } from "react";
-import Image from "next/image";
 import { notFound } from "next/navigation";
 import { log } from "next-axiom";
 
-import { Container } from "@/components/container";
-import { HappeningSidebar } from "@/components/happening-sidebar";
-import { Markdown } from "@/components/markdown";
-import { Heading } from "@/components/typography/heading";
-import { Text } from "@/components/typography/text";
+import { EventPage } from "@/components/event-page";
 import { fetchHappeningBySlug } from "@/sanity/happening/requests";
-import { shortDate } from "@/utils/date";
 
 type Props = {
   params: {
@@ -41,40 +35,5 @@ export const generateMetadata = async ({ params }: Props) => {
 export default async function BedpresPage({ params }: Props) {
   const bedpres = await getData(params.slug);
 
-  return (
-    <Container className="w-full py-10 md:max-w-[700px] lg:max-w-[1500px]">
-      <div className="flex flex-col gap-8 lg:flex-row">
-        <HappeningSidebar event={bedpres} />
-
-        {/* Content */}
-        <article className="w-full">
-          <Heading>{bedpres.title}</Heading>
-
-          {bedpres.body ? (
-            <Markdown content={bedpres.body} />
-          ) : (
-            <div className="mx-auto flex w-fit flex-col gap-8 p-5">
-              <h3 className="text-center text-xl font-medium">Mer informasjon kommer!</h3>
-              <Image
-                className="rounded-lg"
-                src="/gif/wallace-construction.gif"
-                alt="Wallace hammering"
-                width={400}
-                height={400}
-              />
-            </div>
-          )}
-        </article>
-      </div>
-
-      <div className="pt-10 text-center text-muted-foreground lg:mt-auto">
-        <Text size="sm" className="p-0">
-          Publisert: {shortDate(bedpres._createdAt)}
-        </Text>
-        <Text size="sm" className="p-0">
-          Sist oppdatert: {shortDate(bedpres._updatedAt)}
-        </Text>
-      </div>
-    </Container>
-  );
+  return <EventPage event={bedpres} />;
 }

--- a/apps/web/src/components/comments/comment-form.tsx
+++ b/apps/web/src/components/comments/comment-form.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { LuArrowRight as ArrowRight } from "react-icons/lu";
 
 import { addCommentAction } from "@/actions/add-comment";
 import { useToast } from "@/hooks/use-toast";
-import { Button } from "../ui/button";
-import { Textarea } from "../ui/textarea";
+import { CommentTextarea } from "./comment-textarea";
 
 type CommentFormProps = {
   id: string;
@@ -43,18 +43,21 @@ export const CommentForm = ({ id }: CommentFormProps) => {
 
   return (
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    <form onSubmit={handleSumbit} className="flex flex-col gap-4">
-      <Textarea
+    <form onSubmit={handleSumbit} className="flex w-full max-w-[500px] flex-col gap-4">
+      <CommentTextarea
         id="content"
         name="content"
         placeholder="Skriv din kommentar her..."
-        className="h-16 w-full max-w-[400px]"
         value={content}
         onChange={(e) => setContent(e.target.value)}
       />
-      <Button type="submit" className="w-fit">
-        Send
-      </Button>
+      <button
+        type="submit"
+        className="group flex w-fit items-center px-2 font-medium text-muted-foreground hover:underline"
+      >
+        Legg til kommentar
+        <ArrowRight className="ml-1 inline-block transform opacity-0 transition-all group-hover:translate-x-1 group-hover:opacity-100" />
+      </button>
     </form>
   );
 };

--- a/apps/web/src/components/comments/comment-reply-textarea.tsx
+++ b/apps/web/src/components/comments/comment-reply-textarea.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 import { LuSend as Send } from "react-icons/lu";
 
 import { addReplyAction } from "@/actions/add-comment";
-import { Textarea } from "../ui/textarea";
 import { useComment } from "./comment-provider";
+import { CommentTextarea } from "./comment-textarea";
 
 export const CommentReplyTextarea = () => {
   const { commentId, postId, isOpen, setIsOpen } = useComment();
@@ -26,8 +26,8 @@ export const CommentReplyTextarea = () => {
   return (
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     <form onSubmit={handleSubmit}>
-      <Textarea
-        className="h-18 w-full"
+      <CommentTextarea
+        className="max-w-[300px]"
         placeholder="Svar på kommentaren..."
         value={content}
         onChange={(event) => setContent(event.target.value)}

--- a/apps/web/src/components/comments/comment-section.tsx
+++ b/apps/web/src/components/comments/comment-section.tsx
@@ -1,13 +1,15 @@
 import { getUser } from "@/lib/get-user";
+import { cn } from "@/utils/cn";
 import { Heading } from "../typography/heading";
 import { CommentForm } from "./comment-form";
 import { Comments } from "./comments";
 
 type CommentSectionProps = {
   id: string;
+  className?: string;
 };
 
-export const CommentSection = async ({ id }: CommentSectionProps) => {
+export const CommentSection = async ({ id, className }: CommentSectionProps) => {
   const user = await getUser();
 
   if (!user) {
@@ -15,8 +17,10 @@ export const CommentSection = async ({ id }: CommentSectionProps) => {
   }
 
   return (
-    <div className="space-y-4">
-      <Heading level={2}>Kommentarer</Heading>
+    <div className={cn("space-y-4", className)}>
+      <Heading className="font-medium" level={2}>
+        Kommentarer
+      </Heading>
       <CommentForm id={id} />
       <Comments id={id} />
     </div>

--- a/apps/web/src/components/comments/comment-textarea.tsx
+++ b/apps/web/src/components/comments/comment-textarea.tsx
@@ -1,0 +1,28 @@
+import { type TextareaHTMLAttributes } from "react";
+
+import { cn } from "@/utils/cn";
+
+type CommentTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const CommentTextarea = ({ className, value, ...props }: CommentTextareaProps) => {
+  if (typeof value !== "string") {
+    throw new Error("CommentTextarea must have a value prop of type string");
+  }
+
+  const shouldExpand = value.split("\n").length > 1;
+
+  return (
+    <textarea
+      className={cn(
+        "w-full resize-none border-0 border-b-2 border-slate-200 bg-transparent outline-0 transition-all focus:border-0 focus:border-b-2 focus:border-b-muted-foreground focus:ring-0",
+        {
+          "border-b-slate-300": !value,
+        },
+        className,
+      )}
+      rows={shouldExpand ? 2 : 1}
+      value={value}
+      {...props}
+    />
+  );
+};

--- a/apps/web/src/components/comments/comments.tsx
+++ b/apps/web/src/components/comments/comments.tsx
@@ -3,6 +3,7 @@ import { type User } from "@echo-webkom/db/schemas";
 import { getCommentsById } from "@/data/comments/queries";
 import { buildCommentTreeFrom, type CommentTree } from "@/lib/comment-tree";
 import { getUser } from "@/lib/get-user";
+import { cn } from "@/utils/cn";
 import { shortDate } from "@/utils/date";
 import { initials } from "@/utils/string";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
@@ -52,13 +53,24 @@ const ReplyTree = ({ comments, user, depth = 0 }: ReplyTreeProps) => {
             userId={comment.user?.id ?? null}
             isOpen={false}
           >
-            <Avatar className="h-14 w-14">
+            <Avatar className="hidden h-14 w-14 sm:block">
               <AvatarImage src={undefined} />
-              <AvatarFallback>{initials(comment.user?.name ?? "ON")}</AvatarFallback>
+              <AvatarFallback title={comment.user?.name ?? "Andreas Aanes"}>
+                {initials(comment.user?.name ?? "AA")}
+              </AvatarFallback>
             </Avatar>
 
-            <div className="flex flex-col gap-1">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:gap-4">
+            <div
+              className={cn("flex flex-1 flex-col gap-1 sm:pl-0", {
+                "pl-0": depth === 0,
+                "pl-4": depth === 1,
+                "pl-8": depth === 2,
+                "pl-12": depth === 3,
+                "pl-16": depth === 4,
+                "pl-20": depth > 4,
+              })}
+            >
+              <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
                 <h3 className="text-lg font-medium">{comment.user?.name ?? "[slettet]"}</h3>
                 <p className="text-sm text-muted-foreground">{shortDate(comment.createdAt)}</p>
               </div>

--- a/apps/web/src/components/event-page.tsx
+++ b/apps/web/src/components/event-page.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from "react";
+import Image from "next/image";
+
+import { type fetchHappeningBySlug } from "@/sanity/happening";
+import { CommentSection } from "./comments/comment-section";
+import { Container } from "./container";
+import { HappeningSidebar } from "./happening-sidebar";
+import { Markdown } from "./markdown";
+import { Heading } from "./typography/heading";
+
+type EventPageProps = {
+  // The awaited return type of fetchHappeningBySlug with null excluded from the type
+  event: Exclude<Awaited<ReturnType<typeof fetchHappeningBySlug>>, null>;
+};
+
+export const EventPage = ({ event }: EventPageProps) => {
+  return (
+    <Container className="flex w-full py-10 md:max-w-[700px] lg:max-w-[1500px]">
+      <div className="flex flex-col gap-8 lg:flex-row">
+        <HappeningSidebar event={event} />
+
+        {/* Content */}
+        <div className="w-full">
+          <article>
+            <Heading>{event.title}</Heading>
+
+            {event.body ? (
+              <Markdown content={event.body} />
+            ) : (
+              <div className="mx-auto flex w-fit flex-col gap-8 p-5">
+                <h3 className="text-center text-xl font-medium">Mer informasjon kommer!</h3>
+                <Image
+                  className="rounded-lg"
+                  src="/gif/wallace-construction.gif"
+                  alt="Wallace hammering"
+                  width={400}
+                  height={400}
+                />
+              </div>
+            )}
+          </article>
+
+          <Suspense fallback={null}>
+            <CommentSection className="mt-10" id={`event_${event._id}`} />
+          </Suspense>
+        </div>
+      </div>
+
+      {/* <div className="mt-10 text-center text-muted-foreground">
+        <Text size="sm" className="p-0">
+          Publisert: {shortDate(event._createdAt)}
+        </Text>
+        <Text size="sm" className="p-0">
+          Sist oppdatert: {shortDate(event._updatedAt)}
+        </Text>
+      </div> */}
+    </Container>
+  );
+};

--- a/packages/db/drizzle/migrations/0017_light_elektra.sql
+++ b/packages/db/drizzle/migrations/0017_light_elektra.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "post_idx" ON "comment" ("post_id");

--- a/packages/db/drizzle/migrations/meta/0017_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1416 @@
+{
+  "id": "d3e883eb-5b83-4a2d-900f-156e5b6ffd8f",
+  "prevId": "4663786b-5650-4324-948d-13639efb33e3",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_provider_account_id_pk": {
+          "name": "account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.answer": {
+      "name": "answer",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "answer_user_id_user_id_fk": {
+          "name": "answer_user_id_user_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "answer_happening_id_happening_id_fk": {
+          "name": "answer_happening_id_happening_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "answer_question_id_question_id_fk": {
+          "name": "answer_question_id_question_id_fk",
+          "tableFrom": "answer",
+          "tableTo": "question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "answer_user_id_happening_id_question_id_pk": {
+          "name": "answer_user_id_happening_id_question_id_pk",
+          "columns": [
+            "user_id",
+            "happening_id",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "post_idx": {
+          "name": "post_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_user_id_user_id_fk": {
+          "name": "comment_user_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "degree_id_pk": {
+          "name": "degree_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.group": {
+      "name": "group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_id_pk": {
+          "name": "group_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.happenings_to_groups": {
+      "name": "happenings_to_groups",
+      "schema": "",
+      "columns": {
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "happenings_to_groups_happening_id_happening_id_fk": {
+          "name": "happenings_to_groups_happening_id_happening_id_fk",
+          "tableFrom": "happenings_to_groups",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "happenings_to_groups_group_id_group_id_fk": {
+          "name": "happenings_to_groups_group_id_group_id_fk",
+          "tableFrom": "happenings_to_groups",
+          "tableTo": "group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "happenings_to_groups_happening_id_group_id_pk": {
+          "name": "happenings_to_groups_happening_id_group_id_pk",
+          "columns": [
+            "happening_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.happening": {
+      "name": "happening",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "happening_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'event'"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_groups": {
+          "name": "registration_groups",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start_groups": {
+          "name": "registration_start_groups",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_start": {
+          "name": "registration_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_end": {
+          "name": "registration_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "slug_idx": {
+          "name": "slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "happening_id_pk": {
+          "name": "happening_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "happening_slug_unique": {
+          "name": "happening_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.question": {
+      "name": "question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "options": {
+          "name": "options",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_happening_id_happening_id_fk": {
+          "name": "question_happening_id_happening_id_fk",
+          "tableFrom": "question",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "question_id_pk": {
+          "name": "question_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.reaction": {
+      "name": "reaction",
+      "schema": "",
+      "columns": {
+        "react_to_key": {
+          "name": "react_to_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji_id": {
+          "name": "emoji_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reaction_user_id_user_id_fk": {
+          "name": "reaction_user_id_user_id_fk",
+          "tableFrom": "reaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reaction_react_to_key_emoji_id_user_id_pk": {
+          "name": "reaction_react_to_key_emoji_id_user_id_pk",
+          "columns": [
+            "react_to_key",
+            "emoji_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.registration": {
+      "name": "registration",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "unregister_reason": {
+          "name": "unregister_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "registration_changed_at": {
+          "name": "registration_changed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registration_user_id_user_id_fk": {
+          "name": "registration_user_id_user_id_fk",
+          "tableFrom": "registration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "registration_happening_id_happening_id_fk": {
+          "name": "registration_happening_id_happening_id_fk",
+          "tableFrom": "registration",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "registration_user_id_happening_id_pk": {
+          "name": "registration_user_id_happening_id_pk",
+          "columns": [
+            "user_id",
+            "happening_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_session_token_pk": {
+          "name": "session_session_token_pk",
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.site_feedback": {
+      "name": "site_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "feedback_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "site_feedback_id_pk": {
+          "name": "site_feedback_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.spot_range": {
+      "name": "spot_range",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spots": {
+          "name": "spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_year": {
+          "name": "min_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_year": {
+          "name": "max_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spot_range_happening_id_happening_id_fk": {
+          "name": "spot_range_happening_id_happening_id_fk",
+          "tableFrom": "spot_range",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spot_range_id_pk": {
+          "name": "spot_range_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.users_to_groups": {
+      "name": "users_to_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_groups_user_id_user_id_fk": {
+          "name": "users_to_groups_user_id_user_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_groups_group_id_group_id_fk": {
+          "name": "users_to_groups_group_id_group_id_fk",
+          "tableFrom": "users_to_groups",
+          "tableTo": "group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_groups_user_id_group_id_pk": {
+          "name": "users_to_groups_user_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_email": {
+          "name": "alternative_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_from_strike": {
+          "name": "banned_from_strike",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_degree_id_degree_id_fk": {
+          "name": "user_degree_id_degree_id_fk",
+          "tableFrom": "user",
+          "tableTo": "degree",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_id_pk": {
+          "name": "user_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.shopping_list_item": {
+      "name": "shopping_list_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shopping_list_item_user_id_user_id_fk": {
+          "name": "shopping_list_item_user_id_user_id_fk",
+          "tableFrom": "shopping_list_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users_to_shopping_list_items": {
+      "name": "users_to_shopping_list_items",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_to_shopping_list_items_user_id_user_id_fk": {
+          "name": "users_to_shopping_list_items_user_id_user_id_fk",
+          "tableFrom": "users_to_shopping_list_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_to_shopping_list_items_item_id_shopping_list_item_id_fk": {
+          "name": "users_to_shopping_list_items_item_id_shopping_list_item_id_fk",
+          "tableFrom": "users_to_shopping_list_items",
+          "tableTo": "shopping_list_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_to_shopping_list_items_user_id_item_id_pk": {
+          "name": "users_to_shopping_list_items_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.whitelist": {
+      "name": "whitelist",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "whitelist_email_pk": {
+          "name": "whitelist_email_pk",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.strike": {
+      "name": "strike",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strike_info_id": {
+          "name": "strike_info_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "user_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "strike_user_id_user_id_fk": {
+          "name": "strike_user_id_user_id_fk",
+          "tableFrom": "strike",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "strike_strike_info_id_strike_info_id_fk": {
+          "name": "strike_strike_info_id_strike_info_id_fk",
+          "tableFrom": "strike",
+          "tableTo": "strike_info",
+          "columnsFrom": [
+            "strike_info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.strike_info": {
+      "name": "strike_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "happening_id": {
+          "name": "happening_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "strike_info_happening_id_happening_id_fk": {
+          "name": "strike_info_happening_id_happening_id_fk",
+          "tableFrom": "strike_info",
+          "tableTo": "happening",
+          "columnsFrom": [
+            "happening_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "strike_info_issuer_id_user_id_fk": {
+          "name": "strike_info_issuer_id_user_id_fk",
+          "tableFrom": "strike_info",
+          "tableTo": "user",
+          "columnsFrom": [
+            "issuer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.degree_type": {
+      "name": "degree_type",
+      "schema": "public",
+      "values": [
+        "bachelors",
+        "masters",
+        "integrated",
+        "year"
+      ]
+    },
+    "public.feedback_category": {
+      "name": "feedback_category",
+      "schema": "public",
+      "values": [
+        "bug",
+        "feature",
+        "login",
+        "other"
+      ]
+    },
+    "public.happening_type": {
+      "name": "happening_type",
+      "schema": "public",
+      "values": [
+        "bedpres",
+        "event",
+        "external"
+      ]
+    },
+    "public.question_type": {
+      "name": "question_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "textarea",
+        "radio",
+        "checkbox"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "registered",
+        "unregistered",
+        "removed",
+        "waiting",
+        "pending"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "student",
+        "company",
+        "guest",
+        "alum"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1716058797709,
       "tag": "0016_thin_wolfpack",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1716150164053,
+      "tag": "0017_light_elektra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schemas/comments.ts
+++ b/packages/db/schemas/comments.ts
@@ -1,22 +1,28 @@
 import { relations } from "drizzle-orm";
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { nanoid } from "nanoid";
 
 import { users } from ".";
 
-export const comments = pgTable("comment", {
-  id: text("id").notNull().primaryKey().$defaultFn(nanoid),
-  postId: text("post_id").notNull(),
-  parentCommentId: text("parent_comment_id"),
-  userId: text("user_id").references(() => users.id, {
-    onDelete: "set null",
+export const comments = pgTable(
+  "comment",
+  {
+    id: text("id").notNull().primaryKey().$defaultFn(nanoid),
+    postId: text("post_id").notNull(),
+    parentCommentId: text("parent_comment_id"),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at")
+      .notNull()
+      .$onUpdateFn(() => new Date()),
+  },
+  (t) => ({
+    postIdx: index("post_idx").on(t.postId),
   }),
-  content: text("content").notNull(),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at")
-    .notNull()
-    .$onUpdateFn(() => new Date()),
-});
+);
 
 export const commentsInsert = relations(comments, ({ one, many }) => ({
   parentComment: one(comments, {


### PR DESCRIPTION
Denne er kanskje litt heavy.

Gjør om innholdet i `/bedpres/[slug]` og `/arrangementer/[slug]` til en komponent `<EventPage />` sånn at det er lettere å gjøre endringer på begge siden.

Har også gjort litt om på stylingen til kommentarfeltet, ser litt mer moderne ut. 

La også til en index on på `public.comments.postId` sånn at det er raskere å hente ut kommentarer til en post/event/osv.

<details>
<summary>På PC</summary>
<br>

![CleanShot 2024-05-19 at 22 27 48](https://github.com/echo-webkom/echo-web-mono/assets/32321558/9e1f9d5c-410f-468c-8d67-b1e0675ef453)

</details>

<details>
<summary>På mobil</summary>
<br>

![CleanShot 2024-05-19 at 22 28 07](https://github.com/echo-webkom/echo-web-mono/assets/32321558/2e7ac2a8-9111-4337-a70a-d98693e86eca)

</details>
