### PR TITLE
Fix register test

### DIFF
--- a/apps/web/src/components/typography/callout.tsx
+++ b/apps/web/src/components/typography/callout.tsx
@@ -27,6 +27,7 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
           },
           className,
         )}
+        data-testid="callout"
       >
         {!noIcon && (
           <div>

--- a/playwright/web/register.spec.ts
+++ b/playwright/web/register.spec.ts
@@ -117,22 +117,21 @@ test.describe("Register", () => {
     );
   });
 
-  // test("should not be able to register to event with unethical user", async ({ page }) => {
-  //   await loginAs(page, "Unethical");
+  test("should not be able to register to event with unethical user", async ({ page }) => {
+    await loginAs(page, "Unethical");
 
-  //   await page.goto(`/arrangement/${SLUG}`);
+    await page.goto(`/arrangement/${SLUG}`);
 
-  //   await expect(page.getByText("Test i prod med Webkom", { exact: true })).toBeVisible();
-  //   await expect(
-  //     page.getByText("Velkommen til testing i prod med Webkom!", { exact: true }),
-  //   ).toBeVisible();
+    await expect(page.getByText("Test i prod med Webkom", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Velkommen til testing i prod med Webkom!", { exact: true }),
+    ).toBeVisible();
 
-  //   await page.getByRole("button", { name: "One-click påmelding" }).click();
-
-  //   await expect(page.getByTestId("toast")).toContainText(
-  //     "Du må ha fylt ut studieinformasjon for å kunne registrere deg",
-  //   );
-  // });
+    await expect(page.getByRole("button", { name: "One-click påmelding" })).toBeHidden();
+    await expect(page.getByTestId("callout")).toContainText(
+      "Du må fylle ut brukeren din og akkseptere de etiske retningslinjene for å melde deg på.",
+    );
+  });
 
   test("see admin dashboard link", async ({ page }) => {
     await loginAs(page, "Admin");


### PR DESCRIPTION
Fikser register testen. Fikk ikke testen til å fungere tidligere, siden jeg trodde påmeldingsknappen skulle være synlig, men det er den jo selvfølgelig ikke om brukeren ikke kan melde seg på.

Nå asserter den bare at den ikke eksisterer, og at det er en varsel synlig.

