### PR TITLE
change href for coming bedpres button

### DIFF
--- a/apps/web/src/app/(default)/hjem/page.tsx
+++ b/apps/web/src/app/(default)/hjem/page.tsx
@@ -29,7 +29,7 @@ export default async function Home() {
         />
         <ComingHappenings
           title="Kommende bedpres"
-          href="/for-studenter/arrangementer"
+          href="/for-studenter/arrangementer?type=bedpres"
           types={["bedpres"]}
           n={3}
           className="col-span-2 row-span-1"


### PR DESCRIPTION
## Why did you create this PR?

Når man trykket på kommende bedpresser så kom man til oversikten der filter automatisk var alle.

## How did you solve the problem?

Endre href til knappen for å se bedpresser