### PR TITLE
Add validation for spotranges when registration start

### DIFF
--- a/apps/cms/schemas/happening.tsx
+++ b/apps/cms/schemas/happening.tsx
@@ -207,7 +207,15 @@ export default defineType({
       ],
       validation: (Rule) =>
         Rule.custom(
-          (value: Array<{ minYear: number; maxYear: number; _key: string }> | undefined) => {
+          (
+            value: Array<{ minYear: number; maxYear: number; _key: string }> | undefined,
+            context,
+          ) => {
+            const registrationStart = context.document?.registrationStart as Date | undefined;
+            if ((registrationStart && !value) ?? value?.length === 0) {
+              return "Du må legge til minst én plass, eller fjerne påmeldingsdatoen.";
+            }
+
             const spotRanges = value ?? [];
             const invalidSpotranges = spotRanges.filter((spotRange1) => {
               return spotRanges.some((spotRange2) => {


### PR DESCRIPTION
Lar ikke folk lage et arrangement med påmeldingsdato og ingen spotranges.

Problemet her er at man vet noen ganger ikke hvor mange man vil ha med, men vet når man har påmeldingsdato. Men løsningen til dette er bare å legge inn noe placeholder. Som jeg tenker er greit. Sånn man gjorde det før i gamledager.

Dette er mest for oss utviklere, når vi lager test arrangement, men glemmer å legge til spot ranges.

Trenger minst 2 approve på denne. Sånn jeg at jeg vet at det er noe enighet i dette.
