### PR TITLE
ci: speed up tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,13 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types:
+      - opened
+      - synchronize
 
 env:
   ADMIN_KEY: foobar
-  DATABASE_URL: postgres://postgres:postgres@localhost:5432/echo-web
+  DATABASE_URL: postgres://postgres:postgres@postgres:5432/echo-web
 
   API_PORT: 8000
   NEXT_PUBLIC_API_URL: http://localhost:8000
@@ -20,8 +22,6 @@ env:
 
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
-  GITHUB_ACTIONS: "true"
 
 jobs:
   lint:
@@ -93,6 +93,11 @@ jobs:
   test-e2e:
     name: 🎭 E2E Tests
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
 
     services:
       postgres:
@@ -125,9 +130,6 @@ jobs:
       - name: 🏗️ Migrate database
         run: pnpm db:migrate
 
-      - name: 🔃 Sync docs
-        run: pnpm --filter=docs sync
-
       - name: 🆎 Typegen
         run: pnpm --filter=web typegen
 
@@ -136,9 +138,6 @@ jobs:
 
       - name: 👷🏻‍♂️ Build
         run: pnpm build
-
-      - name: 💻 Install playwright browsers
-        run: pnpm --filter=playwright test:install
 
       - name: 🎭 Run playwright tests
         run: pnpm test:e2e
@@ -149,4 +148,4 @@ jobs:
         with:
           name: playwright-report
           path: playwright/playwright-report/
-          retention-days: 30
+          retention-days: 7

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,7 @@ import { serve } from "@hono/node-server";
 
 import app from "./app";
 
-const isGitHubCI = !!process.env.GITHUB_ACTIONS;
-const HOSTNAME = isGitHubCI ? "localhost" : "0.0.0.0";
+const HOSTNAME = "0.0.0.0";
 const PORT = process.env.API_PORT ? Number(process.env.API_PORT) : 8000;
 
 serve(

--- a/turbo.json
+++ b/turbo.json
@@ -60,6 +60,9 @@
   "globalDependencies": [
     ".env"
   ],
+  "globalPassThroughEnv": [
+    "PLAYWRIGHT_*"
+  ],
   "globalEnv": [
     "CI",
     "NODE_ENV",
@@ -82,7 +85,6 @@
     "NEXT_PUBLIC_API_URL",
     "API_PORT",
     "AOC_SESSION_COOKIE",
-    "AUTH_SECRET",
-    "GITHUB_ACTIONS"
+    "AUTH_SECRET"
   ]
 }


### PR DESCRIPTION
Kjør e2e-testen litt raskere ved å bruke Docker-imaget til Playwright. Sparer oss for kanskje 2-3 minutter der vi venter på å laste ned nettleserene hver gang vi kjører testene.

Very nice :+1: