### PR TITLE
feat: create user update endpoint

### DIFF
--- a/apps/uno/bootstrap/api.go
+++ b/apps/uno/bootstrap/api.go
@@ -108,7 +108,7 @@ func RunApi() {
 	degreeService := service.NewDegreeService(degreeRepo)
 	siteFeedbackService := service.NewSiteFeedbackService(siteFeedbackRepo)
 	shoppingListService := service.NewShoppingListService(shoppingListItemRepo, usersToShoppingListItemRepo)
-	userService := service.NewUserService(userRepo, profilePictureRepo)
+	userService := service.NewUserService(userRepo, profilePictureRepo, groupRepo, degreeRepo)
 	strikeService := service.NewStrikeService(dotRepo, banInfoRepo, userRepo)
 	accessRequestService := service.NewAccessRequestService(accessRequestRepo)
 	whitelistService := service.NewWhitelistService(whitelistRepo)

--- a/apps/uno/bootstrap/cron.go
+++ b/apps/uno/bootstrap/cron.go
@@ -102,7 +102,7 @@ func RunCron(job string) {
 	}
 	questionService := service.NewQuestionService(questionRepo)
 	strikeService := service.NewStrikeService(dotRepo, banInfoRepo, userRepo)
-	userService := service.NewUserService(userRepo, profilePictureRepo)
+	userService := service.NewUserService(userRepo, profilePictureRepo, nil, nil)
 
 	// Job to clean up sensitive questions and strikes every 6 months.
 	runner.AddSchedule(cronrunner.Schedule{

--- a/apps/uno/cron/jobs/db_maintenance_test.go
+++ b/apps/uno/cron/jobs/db_maintenance_test.go
@@ -94,7 +94,7 @@ func TestResetUserYearsRun(t *testing.T) {
 		Return(expected, nil).
 		Once()
 
-	userService := service.NewUserService(userRepo, nil)
+	userService := service.NewUserService(userRepo, nil, nil, nil)
 	job := NewResetUserYears(userService, &testutil.NoOpLogger{})
 
 	err := job.Run(t.Context())
@@ -111,7 +111,7 @@ func TestResetUserYearsRunError(t *testing.T) {
 		Return(int64(0), expectedErr).
 		Once()
 
-	userService := service.NewUserService(userRepo, nil)
+	userService := service.NewUserService(userRepo, nil, nil, nil)
 	job := NewResetUserYears(userService, &testutil.NoOpLogger{})
 
 	err := job.Run(t.Context())

--- a/apps/uno/docs/docs.go
+++ b/apps/uno/docs/docs.go
@@ -3559,6 +3559,73 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Updates a user by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/uno_http_dto.UpdateUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/uno_http_dto.UpdateUserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "User Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/users/{id}/ban": {
@@ -6032,6 +6099,40 @@ const docTemplate = `{
                 }
             }
         },
+        "uno_http_dto.UpdateUserRequest": {
+            "type": "object",
+            "properties": {
+                "alternativeEmail": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-string"
+                },
+                "birthday": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-time_Time"
+                },
+                "degreeId": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-string"
+                },
+                "hasReadTerms": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-bool"
+                },
+                "isPublic": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-bool"
+                },
+                "year": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-int"
+                }
+            }
+        },
+        "uno_http_dto.UpdateUserResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
         "uno_http_dto.UserGroupResponse": {
             "type": "object",
             "properties": {
@@ -6232,6 +6333,18 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "uno_pkg_option.Option-bool": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-int": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-string": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-time_Time": {
+            "type": "object"
         }
     },
     "securityDefinitions": {

--- a/apps/uno/docs/swagger.json
+++ b/apps/uno/docs/swagger.json
@@ -3552,6 +3552,73 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Updates a user by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User update payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/uno_http_dto.UpdateUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/uno_http_dto.UpdateUserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "User Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/users/{id}/ban": {
@@ -6025,6 +6092,40 @@
                 }
             }
         },
+        "uno_http_dto.UpdateUserRequest": {
+            "type": "object",
+            "properties": {
+                "alternativeEmail": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-string"
+                },
+                "birthday": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-time_Time"
+                },
+                "degreeId": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-string"
+                },
+                "hasReadTerms": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-bool"
+                },
+                "isPublic": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-bool"
+                },
+                "year": {
+                    "$ref": "#/definitions/uno_pkg_option.Option-int"
+                }
+            }
+        },
+        "uno_http_dto.UpdateUserResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
         "uno_http_dto.UserGroupResponse": {
             "type": "object",
             "properties": {
@@ -6225,6 +6326,18 @@
                     "type": "string"
                 }
             }
+        },
+        "uno_pkg_option.Option-bool": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-int": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-string": {
+            "type": "object"
+        },
+        "uno_pkg_option.Option-time_Time": {
+            "type": "object"
         }
     },
     "securityDefinitions": {

--- a/apps/uno/docs/swagger.yaml
+++ b/apps/uno/docs/swagger.yaml
@@ -1190,6 +1190,28 @@ definitions:
       status:
         type: string
     type: object
+  uno_http_dto.UpdateUserRequest:
+    properties:
+      alternativeEmail:
+        $ref: '#/definitions/uno_pkg_option.Option-string'
+      birthday:
+        $ref: '#/definitions/uno_pkg_option.Option-time_Time'
+      degreeId:
+        $ref: '#/definitions/uno_pkg_option.Option-string'
+      hasReadTerms:
+        $ref: '#/definitions/uno_pkg_option.Option-bool'
+      isPublic:
+        $ref: '#/definitions/uno_pkg_option.Option-bool'
+      year:
+        $ref: '#/definitions/uno_pkg_option.Option-int'
+    type: object
+  uno_http_dto.UpdateUserResponse:
+    properties:
+      message:
+        type: string
+      success:
+        type: boolean
+    type: object
   uno_http_dto.UserGroupResponse:
     properties:
       id:
@@ -1320,6 +1342,14 @@ definitions:
         type: string
       reason:
         type: string
+    type: object
+  uno_pkg_option.Option-bool:
+    type: object
+  uno_pkg_option.Option-int:
+    type: object
+  uno_pkg_option.Option-string:
+    type: object
+  uno_pkg_option.Option-time_Time:
     type: object
 info:
   contact:
@@ -3529,6 +3559,49 @@ paths:
       security:
       - AdminApiKey: []
       summary: Gets a user by ID
+      tags:
+      - users
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: User update payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/uno_http_dto.UpdateUserRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/uno_http_dto.UpdateUserResponse'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: User Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Updates a user by ID
       tags:
       - users
   /users/{id}/ban:

--- a/apps/uno/domain/model/registration.go
+++ b/apps/uno/domain/model/registration.go
@@ -72,7 +72,7 @@ func (r *Registration) CanUnregister() bool {
 
 // Unregister marks the registration as unregistered with a reason.
 func (r *Registration) Unregister(reason string, changedBy string, now time.Time) {
-	r.PrevStatus = stringPtr(string(r.Status))
+	r.PrevStatus = new(string(r.Status))
 	r.Status = RegistrationStatusUnregistered
 	r.UnregisterReason = &reason
 	r.ChangedAt = &now
@@ -81,7 +81,7 @@ func (r *Registration) Unregister(reason string, changedBy string, now time.Time
 
 // Remove marks the registration as removed by an admin.
 func (r *Registration) Remove(changedBy string, now time.Time) {
-	r.PrevStatus = stringPtr(string(r.Status))
+	r.PrevStatus = new(string(r.Status))
 	r.Status = RegistrationStatusRemoved
 	r.ChangedAt = &now
 	r.ChangedBy = &changedBy
@@ -89,7 +89,7 @@ func (r *Registration) Remove(changedBy string, now time.Time) {
 
 // ChangeStatus updates the registration status with audit information.
 func (r *Registration) ChangeStatus(newStatus RegistrationStatus, changedBy string, now time.Time) {
-	r.PrevStatus = stringPtr(string(r.Status))
+	r.PrevStatus = new(string(r.Status))
 	r.Status = newStatus
 	r.ChangedAt = &now
 	r.ChangedBy = &changedBy
@@ -104,9 +104,4 @@ func (r *Registration) HasStatusChanged() bool {
 type RegistrationWithHappening struct {
 	Registration
 	Happening Happening
-}
-
-// Helper function to create a string pointer
-func stringPtr(s string) *string {
-	return &s
 }

--- a/apps/uno/domain/port/group.go
+++ b/apps/uno/domain/port/group.go
@@ -16,4 +16,5 @@ type GroupRepo interface {
 	SetGroupMemberLeader(ctx context.Context, groupID string, userID string, isLeader bool) error
 	AddUserToGroup(ctx context.Context, groupID string, userID string) error
 	RemoveUserFromGroup(ctx context.Context, groupID string, userID string) error
+	RemoveAllUserMemberships(ctx context.Context, userID string) error
 }

--- a/apps/uno/domain/port/mocks/GroupRepo.go
+++ b/apps/uno/domain/port/mocks/GroupRepo.go
@@ -494,6 +494,63 @@ func (_c *GroupRepo_GetUserGroupMembership_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// RemoveAllUserMemberships provides a mock function for the type GroupRepo
+func (_mock *GroupRepo) RemoveAllUserMemberships(ctx context.Context, userID string) error {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAllUserMemberships")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// GroupRepo_RemoveAllUserMemberships_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveAllUserMemberships'
+type GroupRepo_RemoveAllUserMemberships_Call struct {
+	*mock.Call
+}
+
+// RemoveAllUserMemberships is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *GroupRepo_Expecter) RemoveAllUserMemberships(ctx interface{}, userID interface{}) *GroupRepo_RemoveAllUserMemberships_Call {
+	return &GroupRepo_RemoveAllUserMemberships_Call{Call: _e.mock.On("RemoveAllUserMemberships", ctx, userID)}
+}
+
+func (_c *GroupRepo_RemoveAllUserMemberships_Call) Run(run func(ctx context.Context, userID string)) *GroupRepo_RemoveAllUserMemberships_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupRepo_RemoveAllUserMemberships_Call) Return(err error) *GroupRepo_RemoveAllUserMemberships_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *GroupRepo_RemoveAllUserMemberships_Call) RunAndReturn(run func(ctx context.Context, userID string) error) *GroupRepo_RemoveAllUserMemberships_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveUserFromGroup provides a mock function for the type GroupRepo
 func (_mock *GroupRepo) RemoveUserFromGroup(ctx context.Context, groupID string, userID string) error {
 	ret := _mock.Called(ctx, groupID, userID)

--- a/apps/uno/domain/port/mocks/UserRepo.go
+++ b/apps/uno/domain/port/mocks/UserRepo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 	"uno/domain/model"
+	"uno/domain/port"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -901,6 +902,78 @@ func (_c *UserRepo_SearchUsersByName_Call) Return(users []model.User, err error)
 }
 
 func (_c *UserRepo_SearchUsersByName_Call) RunAndReturn(run func(ctx context.Context, query string, limit int) ([]model.User, error)) *UserRepo_SearchUsersByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateUser provides a mock function for the type UserRepo
+func (_mock *UserRepo) UpdateUser(ctx context.Context, userID string, params port.UpdateUserParams) (model.User, error) {
+	ret := _mock.Called(ctx, userID, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUser")
+	}
+
+	var r0 model.User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, port.UpdateUserParams) (model.User, error)); ok {
+		return returnFunc(ctx, userID, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, port.UpdateUserParams) model.User); ok {
+		r0 = returnFunc(ctx, userID, params)
+	} else {
+		r0 = ret.Get(0).(model.User)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, port.UpdateUserParams) error); ok {
+		r1 = returnFunc(ctx, userID, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// UserRepo_UpdateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUser'
+type UserRepo_UpdateUser_Call struct {
+	*mock.Call
+}
+
+// UpdateUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - params port.UpdateUserParams
+func (_e *UserRepo_Expecter) UpdateUser(ctx interface{}, userID interface{}, params interface{}) *UserRepo_UpdateUser_Call {
+	return &UserRepo_UpdateUser_Call{Call: _e.mock.On("UpdateUser", ctx, userID, params)}
+}
+
+func (_c *UserRepo_UpdateUser_Call) Run(run func(ctx context.Context, userID string, params port.UpdateUserParams)) *UserRepo_UpdateUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 port.UpdateUserParams
+		if args[2] != nil {
+			arg2 = args[2].(port.UpdateUserParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *UserRepo_UpdateUser_Call) Return(user model.User, err error) *UserRepo_UpdateUser_Call {
+	_c.Call.Return(user, err)
+	return _c
+}
+
+func (_c *UserRepo_UpdateUser_Call) RunAndReturn(run func(ctx context.Context, userID string, params port.UpdateUserParams) (model.User, error)) *UserRepo_UpdateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/apps/uno/domain/port/user.go
+++ b/apps/uno/domain/port/user.go
@@ -4,7 +4,17 @@ import (
 	"context"
 	"time"
 	"uno/domain/model"
+	"uno/pkg/option"
 )
+
+type UpdateUserParams struct {
+	AlternativeEmail option.Option[*string]
+	DegreeID         option.Option[*string]
+	Year             option.Option[*int]
+	HasReadTerms     option.Option[*bool]
+	Birthday         option.Option[*time.Time]
+	IsPublic         option.Option[*bool]
+}
 
 type UserRepo interface {
 	GetAllUsers(ctx context.Context) ([]model.User, error)
@@ -17,6 +27,7 @@ type UserRepo interface {
 	GetUserWithStrikeDetailsByID(ctx context.Context, userID string) (*model.UserWithStrikeDetails, error)
 	GetUserMemberships(ctx context.Context, userID string) ([]string, error)
 	CreateUser(ctx context.Context, user model.User) (model.User, error)
+	UpdateUser(ctx context.Context, userID string, params UpdateUserParams) (model.User, error)
 	UpdateUserImage(ctx context.Context, userID string, hasImage bool) error
 	SearchUsersByName(ctx context.Context, query string, limit int) ([]model.User, error)
 	GetUserByEmail(ctx context.Context, email string) (model.User, error)

--- a/apps/uno/domain/service/auth.go
+++ b/apps/uno/domain/service/auth.go
@@ -9,7 +9,6 @@ import (
 	"uno/domain/model"
 	"uno/domain/port"
 	"uno/domain/service/providers"
-	"uno/pkg/ptr"
 	"uno/pkg/randid"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -316,8 +315,8 @@ func (as *AuthService) SignInWithFeide(ctx context.Context, code string) (userID
 	if existingAccount.UserID != "" {
 		if _, err = as.accountRepo.UpdateAccount(ctx, providers.FeideProviderName, userInfo.Sub, model.UpdateAccount{
 			AccessToken:  &tokens.AccessToken,
-			RefreshToken: ptr.Of(tokens.RefreshToken),
-			ExpiresAt:    ptr.Of(tokens.ExpiresIn),
+			RefreshToken: new(tokens.RefreshToken),
+			ExpiresAt:    new(tokens.ExpiresIn),
 			TokenType:    &tokens.TokenType,
 			IDToken:      &tokens.IDToken,
 		}); err != nil {
@@ -335,10 +334,10 @@ func (as *AuthService) SignInWithFeide(ctx context.Context, code string) (userID
 			Provider:          providers.FeideProviderName,
 			ProviderAccountID: userInfo.Sub,
 			AccessToken:       &tokens.AccessToken,
-			RefreshToken:      ptr.Of(tokens.RefreshToken),
-			ExpiresAt:         ptr.Of(tokens.ExpiresIn),
+			RefreshToken:      new(tokens.RefreshToken),
+			ExpiresAt:         new(tokens.ExpiresIn),
 			TokenType:         &tokens.TokenType,
-			Scope:             ptr.Of("openid email profile groups"),
+			Scope:             new("openid email profile groups"),
 			IDToken:           &tokens.IDToken,
 		}); err != nil {
 			return "", "", fmt.Errorf("failed to link Feide account to existing user: %w", err)

--- a/apps/uno/domain/service/shopping_list_test.go
+++ b/apps/uno/domain/service/shopping_list_test.go
@@ -24,7 +24,7 @@ func TestShoppingListService_GetShoppingList(t *testing.T) {
 				Name:      "Ost",
 				CreatedAt: time,
 			},
-			UserName: strPtr("Bob"),
+			UserName: new("Bob"),
 		},
 		{
 			ShoppingListItem: model.ShoppingListItem{
@@ -33,7 +33,7 @@ func TestShoppingListService_GetShoppingList(t *testing.T) {
 				Name:      "Mjölk",
 				CreatedAt: time,
 			},
-			UserName: strPtr("Alice"),
+			UserName: new("Alice"),
 		},
 		{
 			ShoppingListItem: model.ShoppingListItem{
@@ -87,7 +87,7 @@ func TestShoppingListService_GetShoppingList(t *testing.T) {
 			ID:        "1",
 			Name:      "Ost",
 			UserID:    "1",
-			UserName:  strPtr("Bob"),
+			UserName:  new("Bob"),
 			CreatedAt: time,
 			Likes:     []string{"2", "3"},
 		},
@@ -95,7 +95,7 @@ func TestShoppingListService_GetShoppingList(t *testing.T) {
 			ID:        "2",
 			Name:      "Mjölk",
 			UserID:    "2",
-			UserName:  strPtr("Alice"),
+			UserName:  new("Alice"),
 			CreatedAt: time,
 			Likes:     []string{"1"},
 		},
@@ -177,9 +177,4 @@ func TestShoppingListService_DeleteShoppingListItem(t *testing.T) {
 
 	err := shoppingListService.DeleteShoppingListItem(t.Context(), itemID)
 	assert.NoError(t, err)
-}
-
-// Helper function to create a string pointer
-func strPtr(s string) *string {
-	return &s
 }

--- a/apps/uno/domain/service/user.go
+++ b/apps/uno/domain/service/user.go
@@ -8,20 +8,31 @@ import (
 	"uno/domain/port"
 )
 
-var ErrFileStorageNotConfigured = errors.New("file storage not configured")
+var (
+	ErrFileStorageNotConfigured = errors.New("file storage not configured")
+	ErrInvalidEmail             = errors.New("invalid email format")
+	ErrInvalidYear              = errors.New("year must be between 1 and 5")
+	ErrDegreeNotFound           = errors.New("degree not found")
+)
 
 type UserService struct {
 	userRepo           port.UserRepo
 	profilePictureRepo port.ProfilePictureRepo
+	groupRepo          port.GroupRepo
+	degreeRepo         port.DegreeRepo
 }
 
 func NewUserService(
 	userRepo port.UserRepo,
 	profilePictureRepo port.ProfilePictureRepo,
+	groupRepo port.GroupRepo,
+	degreeRepo port.DegreeRepo,
 ) *UserService {
 	return &UserService{
 		userRepo:           userRepo,
 		profilePictureRepo: profilePictureRepo,
+		groupRepo:          groupRepo,
+		degreeRepo:         degreeRepo,
 	}
 }
 
@@ -106,4 +117,57 @@ func (s *UserService) UploadProfileImage(ctx context.Context, userID string, pro
 
 	// Mark that the user has a profile picture
 	return s.userRepo.UpdateUserImage(ctx, userID, true)
+}
+
+func (s *UserService) UpdateUser(ctx context.Context, userID string, params port.UpdateUserParams) (model.User, error) {
+	// Validate alternative email if provided
+	if params.AlternativeEmail.IsSome() {
+		email := params.AlternativeEmail.Value()
+		if email != nil {
+			_, err := model.NewEmail(*email)
+			if err != nil {
+				return model.User{}, ErrInvalidEmail
+			}
+		}
+	}
+
+	// Validate degree ID if provided
+	if params.DegreeID.IsSome() {
+		degreeID := params.DegreeID.Value()
+		if degreeID != nil {
+			if !s.isValidDegree(ctx, *degreeID) {
+				return model.User{}, ErrDegreeNotFound
+			}
+		}
+	}
+
+	// Validate year if provided
+	if params.Year.IsSome() {
+		year := params.Year.Value()
+		if year != nil {
+			_, err := model.NewDegreeYear(*year)
+			if err != nil {
+				return model.User{}, ErrInvalidYear
+			}
+		}
+	}
+
+	return s.userRepo.UpdateUser(ctx, userID, params)
+}
+
+// isValidDegree checks if a degree ID exists in the database
+func (s *UserService) isValidDegree(ctx context.Context, degreeID string) bool {
+	if s.degreeRepo == nil {
+		return true // Skip validation if degreeRepo is not configured
+	}
+	degrees, err := s.degreeRepo.GetAllDegrees(ctx)
+	if err != nil {
+		return true // Skip validation on error
+	}
+	for _, degree := range degrees {
+		if degree.ID == degreeID {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/uno/domain/service/user_test.go
+++ b/apps/uno/domain/service/user_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 	"uno/domain/model"
+	"uno/domain/port"
 	"uno/domain/port/mocks"
 	"uno/domain/service"
+	"uno/pkg/option"
 	"uno/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +95,151 @@ func TestUserService_GetUsersWithBirthdayToday_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, users)
+}
+
+func TestUserService_UpdateUser(t *testing.T) {
+	validDegreeID := "inf"
+	validDegree := testutil.NewFakeStruct(func(d *model.Degree) { d.ID = validDegreeID })
+
+	tests := []struct {
+		name          string
+		params        port.UpdateUserParams
+		setupMocks    func(*mocks.UserRepo, *mocks.DegreeRepo)
+		nilDegreeRepo bool
+		expectedErr   error
+	}{
+		{
+			name: "success — valid email, degree, and year",
+			params: port.UpdateUserParams{
+				AlternativeEmail: option.New(new("valid@example.com")),
+				DegreeID:         option.New(new(validDegreeID)),
+				Year:             option.New(new(3)),
+			},
+			setupMocks: func(userRepo *mocks.UserRepo, degreeRepo *mocks.DegreeRepo) {
+				degreeRepo.EXPECT().
+					GetAllDegrees(mock.Anything).
+					Return([]model.Degree{validDegree}, nil).
+					Once()
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+		},
+		{
+			name: "invalid email",
+			params: port.UpdateUserParams{
+				AlternativeEmail: option.New(strPtr("not-an-email")),
+			},
+			setupMocks:  func(*mocks.UserRepo, *mocks.DegreeRepo) {},
+			expectedErr: service.ErrInvalidEmail,
+		},
+		{
+			name: "nil email skips validation",
+			params: port.UpdateUserParams{
+				AlternativeEmail: option.New[*string](nil),
+				Year:             option.New(new(2)),
+			},
+			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+		},
+		{
+			name: "absent email skips validation",
+			params: port.UpdateUserParams{
+				Year: option.New(new(1)),
+			},
+			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+		},
+		{
+			name: "invalid year",
+			params: port.UpdateUserParams{
+				Year: option.New(new(0)),
+			},
+			setupMocks:  func(*mocks.UserRepo, *mocks.DegreeRepo) {},
+			expectedErr: service.ErrInvalidYear,
+		},
+		{
+			name: "valid year passes through",
+			params: port.UpdateUserParams{
+				Year: option.New(new(6)),
+			},
+			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+		},
+		{
+			name: "degree not in list",
+			params: port.UpdateUserParams{
+				DegreeID: option.New(strPtr("unknown-degree")),
+			},
+			setupMocks: func(_ *mocks.UserRepo, degreeRepo *mocks.DegreeRepo) {
+				degreeRepo.EXPECT().
+					GetAllDegrees(mock.Anything).
+					Return([]model.Degree{validDegree}, nil).
+					Once()
+			},
+			expectedErr: service.ErrDegreeNotFound,
+		},
+		{
+			name: "nil degreeRepo skips degree validation",
+			params: port.UpdateUserParams{
+				DegreeID: option.New(strPtr("any-id")),
+			},
+			nilDegreeRepo: true,
+			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+		},
+		{
+			name: "repo error propagated",
+			params: port.UpdateUserParams{
+				Year: option.New(new(2)),
+			},
+			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, "user-1", mock.Anything).
+					Return(model.User{}, errors.New("db failure")).
+					Once()
+			},
+			expectedErr: errors.New("db failure"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUserRepo := mocks.NewUserRepo(t)
+			mockDegreeRepo := mocks.NewDegreeRepo(t)
+			tt.setupMocks(mockUserRepo, mockDegreeRepo)
+
+			var userService *service.UserService
+			if tt.nilDegreeRepo {
+				userService = service.NewUserService(mockUserRepo, nil, nil, nil)
+			} else {
+				userService = service.NewUserService(mockUserRepo, nil, nil, mockDegreeRepo)
+			}
+
+			_, err := userService.UpdateUser(context.Background(), "user-1", tt.params)
+
+			if tt.expectedErr != nil {
+				assert.ErrorContains(t, err, tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/apps/uno/domain/service/user_test.go
+++ b/apps/uno/domain/service/user_test.go
@@ -17,7 +17,7 @@ import (
 func TestUserService_GetAllUsers(t *testing.T) {
 	mockRepo := mocks.NewUserRepo(t)
 	mockProfilePictureStore := mocks.NewProfilePictureRepo(t)
-	userService := service.NewUserService(mockRepo, mockProfilePictureStore)
+	userService := service.NewUserService(mockRepo, mockProfilePictureStore, nil, nil)
 
 	expectedUsers := []model.User{testutil.NewFakeStruct[model.User]()}
 	mockRepo.EXPECT().GetAllUsers(mock.Anything).Return(expectedUsers, nil).Once()
@@ -50,7 +50,7 @@ func TestUserService_GetUsersWithBirthdayToday_Success(t *testing.T) {
 		Once()
 
 	mockProfilePictureStore := mocks.NewProfilePictureRepo(t)
-	userService := service.NewUserService(mockRepo, mockProfilePictureStore)
+	userService := service.NewUserService(mockRepo, mockProfilePictureStore, nil, nil)
 	users, err := userService.GetUsersWithBirthdayToday(ctx)
 
 	assert.NoError(t, err)
@@ -69,7 +69,7 @@ func TestUserService_GetUsersWithBirthdayToday_Empty(t *testing.T) {
 		Once()
 
 	mockProfilePictureStore := mocks.NewProfilePictureRepo(t)
-	userService := service.NewUserService(mockRepo, mockProfilePictureStore)
+	userService := service.NewUserService(mockRepo, mockProfilePictureStore, nil, nil)
 	users, err := userService.GetUsersWithBirthdayToday(ctx)
 
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestUserService_GetUsersWithBirthdayToday_Error(t *testing.T) {
 		Once()
 
 	mockProfilePictureStore := mocks.NewProfilePictureRepo(t)
-	userService := service.NewUserService(mockRepo, mockProfilePictureStore)
+	userService := service.NewUserService(mockRepo, mockProfilePictureStore, nil, nil)
 	users, err := userService.GetUsersWithBirthdayToday(ctx)
 
 	assert.Error(t, err)

--- a/apps/uno/domain/service/user_test.go
+++ b/apps/uno/domain/service/user_test.go
@@ -129,7 +129,7 @@ func TestUserService_UpdateUser(t *testing.T) {
 		{
 			name: "invalid email",
 			params: port.UpdateUserParams{
-				AlternativeEmail: option.New(strPtr("not-an-email")),
+				AlternativeEmail: option.New(new("not-an-email")),
 			},
 			setupMocks:  func(*mocks.UserRepo, *mocks.DegreeRepo) {},
 			expectedErr: service.ErrInvalidEmail,
@@ -182,7 +182,7 @@ func TestUserService_UpdateUser(t *testing.T) {
 		{
 			name: "degree not in list",
 			params: port.UpdateUserParams{
-				DegreeID: option.New(strPtr("unknown-degree")),
+				DegreeID: option.New(new("unknown-degree")),
 			},
 			setupMocks: func(_ *mocks.UserRepo, degreeRepo *mocks.DegreeRepo) {
 				degreeRepo.EXPECT().
@@ -195,7 +195,7 @@ func TestUserService_UpdateUser(t *testing.T) {
 		{
 			name: "nil degreeRepo skips degree validation",
 			params: port.UpdateUserParams{
-				DegreeID: option.New(strPtr("any-id")),
+				DegreeID: option.New(new("any-id")),
 			},
 			nilDegreeRepo: true,
 			setupMocks: func(userRepo *mocks.UserRepo, _ *mocks.DegreeRepo) {

--- a/apps/uno/http/dto/users.go
+++ b/apps/uno/http/dto/users.go
@@ -3,7 +3,25 @@ package dto
 import (
 	"time"
 	"uno/domain/model"
+	"uno/pkg/option"
 )
+
+// UpdateUserRequest represents the request body for updating a user.
+// All fields are optional and will only be updated if they are provided.
+type UpdateUserRequest struct {
+	AlternativeEmail option.Option[*string]    `json:"alternativeEmail"`
+	DegreeID         option.Option[*string]    `json:"degreeId"`
+	Year             option.Option[*int]       `json:"year"`
+	HasReadTerms     option.Option[*bool]      `json:"hasReadTerms"`
+	Birthday         option.Option[*time.Time] `json:"birthday"`
+	IsPublic         option.Option[*bool]      `json:"isPublic"`
+}
+
+// UpdateUserResponse represents the response after updating a user.
+type UpdateUserResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
 
 type UserSearchResult struct {
 	ID   string  `json:"id"`

--- a/apps/uno/http/routes/api/birthday_test.go
+++ b/apps/uno/http/routes/api/birthday_test.go
@@ -74,7 +74,7 @@ func TestBirthdaysTodayHandler(t *testing.T) {
 			mockProfilePictureStore := mocks.NewProfilePictureRepo(t)
 			tt.setupMocks(mockUserRepo)
 
-			userService := service.NewUserService(mockUserRepo, mockProfilePictureStore)
+			userService := service.NewUserService(mockUserRepo, mockProfilePictureStore, nil, nil)
 			mux := api.NewBirthdayMux(testutil.NewTestLogger(), userService)
 
 			r := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/apps/uno/http/routes/api/happening.go
+++ b/apps/uno/http/routes/api/happening.go
@@ -419,7 +419,7 @@ func (h *happenings) deregisterFromHappening(ctx *handler.Context) error {
 		req.UserID,
 		happeningID,
 		model.RegistrationStatusUnregistered,
-		stringPtr(string(reg.Status)),
+		new(string(reg.Status)),
 		nil,
 		&now,
 		&req.Reason,
@@ -499,7 +499,7 @@ func (h *happenings) updateRegistrationStatus(ctx *handler.Context) error {
 		userID,
 		happeningID,
 		status,
-		stringPtr(string(reg.Status)),
+		new(string(reg.Status)),
 		&changedBy,
 		&now,
 		&req.Reason,
@@ -531,8 +531,4 @@ func (h *happenings) deleteAllRegistrations(ctx *handler.Context) error {
 	}
 
 	return ctx.Ok()
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/apps/uno/http/routes/api/users.go
+++ b/apps/uno/http/routes/api/users.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
+	"slices"
 	"strconv"
 	"uno/domain/model"
 	"uno/domain/port"
@@ -20,7 +21,14 @@ type users struct {
 	strikeService    *service.StrikeService
 }
 
-func NewUsersMux(logger port.Logger, userService *service.UserService, happeningService *service.HappeningService, strikeService *service.StrikeService, admin handler.Middleware, session handler.Middleware) *router.Mux {
+func NewUsersMux(
+	logger port.Logger,
+	userService *service.UserService,
+	happeningService *service.HappeningService,
+	strikeService *service.StrikeService,
+	admin handler.Middleware,
+	session handler.Middleware,
+) *router.Mux {
 	u := users{logger, userService, happeningService, strikeService}
 
 	mux := router.NewMux()
@@ -30,6 +38,8 @@ func NewUsersMux(logger port.Logger, userService *service.UserService, happening
 	mux.GET("/with-strikes", u.getUsersWithStrikeDetails, admin)
 
 	mux.GET("/{id}", u.getUserByID, admin)
+	mux.PATCH("/{id}", u.updateUser, session)
+
 	mux.GET("/{id}/registrations", u.getUserRegistrations, admin)
 	mux.GET("/{id}/strikes", u.getUserWithStrikeDetails, admin)
 	mux.POST("/{id}/strikes", u.addStrike, admin)
@@ -130,6 +140,87 @@ func (u *users) getUserByID(ctx *handler.Context) error {
 	// Map user to user response
 	response := dto.UserResponseFromDomain(user)
 	return ctx.JSON(response)
+}
+
+// updateUser updates a user by ID
+// @Summary	     Updates a user by ID
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Param        id   path      string               true  "User ID"
+// @Param        body body      dto.UpdateUserRequest true  "User update payload"
+// @Success      200  {object}  dto.UpdateUserResponse  "OK"
+// @Failure      400  {string}  string  "Bad Request"
+// @Failure      401  {string}  string  "Unauthorized"
+// @Failure      404  {string}  string  "User Not Found"
+// @Failure      500  {string}  string  "Internal Server Error"
+// @Security     BearerAuth
+// @Router       /users/{id} [patch]
+func (u *users) updateUser(ctx *handler.Context) error {
+	// Get user ID from path parameters
+	userID := ctx.PathValue("id")
+	if userID == "" {
+		return ctx.BadRequest(errors.New("missing user ID"))
+	}
+
+	// Get the current user from context and verify they are updating their own profile
+	currentUser, ok := handler.UserFromContext(ctx.Context())
+	if !ok {
+		return ctx.Unauthorized(errors.New("user not found in context"))
+	}
+	if currentUser.ID != userID {
+		return ctx.Forbidden(errors.New("cannot update another user's profile"))
+	}
+
+	// Parse request body
+	var req dto.UpdateUserRequest
+	if err := ctx.ReadJSON(&req); err != nil {
+		return ctx.BadRequest(ErrFailedToReadJSON)
+	}
+
+	// Check if at least one field is provided for update
+	hasProfileFields := slices.Contains([]bool{
+		req.AlternativeEmail.IsSome(),
+		req.DegreeID.IsSome(),
+		req.Year.IsSome(),
+		req.HasReadTerms.IsSome(),
+		req.Birthday.IsSome(),
+		req.IsPublic.IsSome(),
+	}, true)
+
+	// If no fields are provided, return a bad request error
+	if !hasProfileFields {
+		return ctx.BadRequest(errors.New("no fields to update"))
+	}
+
+	updateParams := port.UpdateUserParams{
+		AlternativeEmail: req.AlternativeEmail,
+		DegreeID:         req.DegreeID,
+		Year:             req.Year,
+		HasReadTerms:     req.HasReadTerms,
+		Birthday:         req.Birthday,
+		IsPublic:         req.IsPublic,
+	}
+
+	_, err := u.userService.UpdateUser(ctx.Context(), userID, updateParams)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ctx.NotFound(errors.New("user not found"))
+		}
+		// Check for validation errors
+		if errors.Is(err, service.ErrInvalidEmail) ||
+			errors.Is(err, service.ErrInvalidYear) ||
+			errors.Is(err, service.ErrDegreeNotFound) {
+			return ctx.BadRequest(err)
+		}
+		u.logger.Error(ctx.Context(), "failed to update user", "userID", userID, "error", err)
+		return ctx.InternalServerError()
+	}
+
+	return ctx.JSON(dto.UpdateUserResponse{
+		Success: true,
+		Message: "User updated successfully",
+	})
 }
 
 // getUserImage returns a user's profile image

--- a/apps/uno/http/routes/api/users_test.go
+++ b/apps/uno/http/routes/api/users_test.go
@@ -2,17 +2,20 @@ package api_test
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"uno/domain/model"
+	"uno/domain/port"
 	"uno/domain/port/mocks"
 	"uno/domain/service"
 	"uno/http/handler"
 	"uno/http/router"
 	"uno/http/routes/api"
+	"uno/pkg/option"
 	"uno/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +25,11 @@ import (
 func newUsersTestMux(t *testing.T, strikeService *service.StrikeService) *router.Mux {
 	t.Helper()
 	return api.NewUsersMux(testutil.NewTestLogger(), nil, nil, strikeService, handler.NoMiddleware, handler.NoMiddleware)
+}
+
+func newUpdateUserTestMux(t *testing.T, userService *service.UserService) *router.Mux {
+	t.Helper()
+	return api.NewUsersMux(testutil.NewTestLogger(), userService, nil, nil, handler.NoMiddleware, handler.NoMiddleware)
 }
 
 func TestGetUsersWithStrikeDetails(t *testing.T) {
@@ -236,6 +244,163 @@ func TestRemoveStrikeHandler(t *testing.T) {
 			r.SetPathValue("strikeId", tt.strikeID)
 			w := httptest.NewRecorder()
 
+			mux.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestUpdateUserHandler(t *testing.T) {
+	const userID = "user-1"
+	currentUser := testutil.NewFakeStruct(func(u *model.User) { u.ID = userID })
+
+	validBody := port.UpdateUserParams{
+		Year: option.New(func() *int { v := 3; return &v }()),
+	}
+
+	marshalBody := func(v any) *bytes.Buffer {
+		b, _ := json.Marshal(v)
+		return bytes.NewBuffer(b)
+	}
+
+	tests := []struct {
+		name           string
+		pathID         string
+		body           *bytes.Buffer
+		injectUser     bool
+		setupMocks     func(*mocks.UserRepo)
+		expectedStatus int
+	}{
+		{
+			name:       "success",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(testutil.NewFakeStruct[model.User](), nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "unauthorized — no user in context",
+			pathID:         userID,
+			body:           marshalBody(validBody),
+			injectUser:     false,
+			setupMocks:     func(*mocks.UserRepo) {},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "forbidden — updating another user",
+			pathID:         "other-user",
+			body:           marshalBody(validBody),
+			injectUser:     true,
+			setupMocks:     func(*mocks.UserRepo) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "bad request — no fields provided",
+			pathID:         userID,
+			body:           bytes.NewBufferString("{}"),
+			injectUser:     true,
+			setupMocks:     func(*mocks.UserRepo) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "bad request — invalid JSON",
+			pathID:         userID,
+			body:           bytes.NewBufferString("not-json"),
+			injectUser:     true,
+			setupMocks:     func(*mocks.UserRepo) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "bad request — invalid email from service",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(model.User{}, service.ErrInvalidEmail).
+					Once()
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "bad request — invalid year from service",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(model.User{}, service.ErrInvalidYear).
+					Once()
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "bad request — degree not found from service",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(model.User{}, service.ErrDegreeNotFound).
+					Once()
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "not found — user does not exist",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(model.User{}, sql.ErrNoRows).
+					Once()
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:       "internal server error",
+			pathID:     userID,
+			body:       marshalBody(validBody),
+			injectUser: true,
+			setupMocks: func(userRepo *mocks.UserRepo) {
+				userRepo.EXPECT().
+					UpdateUser(mock.Anything, userID, mock.Anything).
+					Return(model.User{}, errors.New("unexpected db error")).
+					Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUserRepo := mocks.NewUserRepo(t)
+			tt.setupMocks(mockUserRepo)
+
+			userService := service.NewUserService(mockUserRepo, nil, nil, nil)
+			mux := newUpdateUserTestMux(t, userService)
+
+			r := httptest.NewRequest(http.MethodPatch, "/"+tt.pathID, tt.body)
+			r.Header.Set("Content-Type", "application/json")
+			r.SetPathValue("id", tt.pathID)
+
+			if tt.injectUser {
+				r = r.WithContext(handler.WithUser(r.Context(), currentUser))
+			}
+
+			w := httptest.NewRecorder()
 			mux.ServeHTTP(w, r)
 
 			assert.Equal(t, tt.expectedStatus, w.Code)

--- a/apps/uno/infrastructure/postgres/group.go
+++ b/apps/uno/infrastructure/postgres/group.go
@@ -290,3 +290,24 @@ func (g *GroupRepo) RemoveUserFromGroup(ctx context.Context, groupID string, use
 
 	return nil
 }
+
+func (g *GroupRepo) RemoveAllUserMemberships(ctx context.Context, userID string) error {
+	g.logger.Info(ctx, "removing all user memberships",
+		"user_id", userID,
+	)
+
+	query := `--sql
+		DELETE FROM users_to_groups
+		WHERE user_id = $1
+	`
+
+	if _, err := g.db.ExecContext(ctx, query, userID); err != nil {
+		g.logger.Error(ctx, "failed to remove all user memberships",
+			"error", err,
+			"user_id", userID,
+		)
+		return err
+	}
+
+	return nil
+}

--- a/apps/uno/infrastructure/postgres/user.go
+++ b/apps/uno/infrastructure/postgres/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 	"uno/domain/model"
 	"uno/domain/port"
@@ -605,6 +606,107 @@ func (u *UserRepo) CreateUser(ctx context.Context, user model.User) (model.User,
 		return model.User{}, err
 	}
 	return result, nil
+}
+
+func (u *UserRepo) UpdateUser(ctx context.Context, userID string, params port.UpdateUserParams) (model.User, error) {
+	u.logger.Info(ctx, "updating user",
+		"user_id", userID,
+	)
+
+	// Build dynamic update query based on provided params
+	setClauses := []string{}
+	args := []any{}
+	argIndex := 1
+
+	// Add alternative_email field
+	if params.AlternativeEmail.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("alternative_email = $%d", argIndex))
+		args = append(args, params.AlternativeEmail.Value())
+		argIndex++
+		// Reset verified timestamp when email changes
+		setClauses = append(setClauses, fmt.Sprintf("alternative_email_verified_at = $%d", argIndex))
+		args = append(args, nil)
+		argIndex++
+	}
+
+	// Add degree_id field
+	if params.DegreeID.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("degree_id = $%d", argIndex))
+		args = append(args, params.DegreeID.Value())
+		argIndex++
+	}
+
+	// Add year field
+	if params.Year.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("year = $%d", argIndex))
+		args = append(args, params.Year.Value())
+		argIndex++
+	}
+
+	// Add has_read_terms field
+	if params.HasReadTerms.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("has_read_terms = $%d", argIndex))
+		args = append(args, params.HasReadTerms.Value())
+		argIndex++
+	}
+
+	// Add birthday field
+	if params.Birthday.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("birthday = $%d", argIndex))
+		args = append(args, params.Birthday.Value())
+		argIndex++
+	}
+
+	// Add is_public field
+	if params.IsPublic.IsSome() {
+		setClauses = append(setClauses, fmt.Sprintf("is_public = $%d", argIndex))
+		args = append(args, params.IsPublic.Value())
+		argIndex++
+	}
+
+	if len(setClauses) == 0 {
+		// No fields to update, just return the current user
+		return u.GetUserByID(ctx, userID)
+	}
+
+	// Add updated_at
+	setClauses = append(setClauses, "updated_at = NOW()")
+
+	sets := strings.Join(setClauses, ", ")
+	query := fmt.Sprintf(`--sql
+		UPDATE "user"
+		SET %s
+		WHERE id = $%d
+		RETURNING id, name, email, image, alternative_email, alternative_email_verified_at, degree_id, year, type, last_sign_in_at, updated_at, created_at, has_read_terms, birthday, is_public
+	`, sets, argIndex)
+
+	args = append(args, userID)
+
+	var resultDB record.UserDB
+	if err := u.db.GetContext(ctx, &resultDB, query, args...); err != nil {
+		u.logger.Error(ctx, "failed to update user",
+			"error", err,
+			"user_id", userID,
+		)
+		return model.User{}, err
+	}
+
+	// Fetch groups for the user
+	groupsQuery := `--sql
+		SELECT g.id, g.name, utg.is_leader
+		FROM users_to_groups utg
+		JOIN "group" g ON utg.group_id = g.id
+		WHERE utg.user_id = $1
+	`
+	if err := u.db.SelectContext(ctx, &resultDB.Groups, groupsQuery, userID); err != nil {
+		u.logger.Error(ctx, "failed to get user groups",
+			"error", err,
+			"user_id", userID,
+		)
+		return model.User{}, err
+	}
+
+	return resultDB.ToDomain()
 }
 
 func (u *UserRepo) SearchUsersByName(ctx context.Context, query string, limit int) ([]model.User, error) {

--- a/apps/uno/pkg/option/option.go
+++ b/apps/uno/pkg/option/option.go
@@ -1,0 +1,42 @@
+package option
+
+import (
+	"encoding/json"
+)
+
+// Option represents a value that may or may not be present.
+// IsSome() is false when the field was absent from JSON, true when it was
+// explicitly provided (even as null).
+type Option[T any] struct {
+	value  T
+	isSome bool
+}
+
+// New creates a new Maybe with the given value. The isSome field is set to true.
+func New[T any](value T) Option[T] {
+	return Option[T]{value: value, isSome: true}
+}
+
+// Value returns the underlying value pointer.
+func (n Option[T]) Value() T {
+	return n.value
+}
+
+// IsSome returns true if the field was provided (even if the value is nil)
+func (n Option[T]) IsSome() bool {
+	return n.isSome
+}
+
+// MarshalJSON implements json.Marshaler.
+func (n Option[T]) MarshalJSON() ([]byte, error) {
+	if !n.isSome {
+		return []byte("null"), nil
+	}
+	return json.Marshal(n.value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (n *Option[T]) UnmarshalJSON(data []byte) error {
+	n.isSome = true
+	return json.Unmarshal(data, &n.value)
+}

--- a/apps/uno/pkg/ptr/ptr.go
+++ b/apps/uno/pkg/ptr/ptr.go
@@ -1,6 +1,0 @@
-package ptr
-
-// Of creates a pointer to the given value.
-func Of[T any](v T) *T {
-	return &v
-}

--- a/apps/web/src/actions/user.ts
+++ b/apps/web/src/actions/user.ts
@@ -1,13 +1,11 @@
 "use server";
 
-import { insertUserSchema, users, usersToGroups } from "@echo-webkom/db/schemas";
-import { db } from "@echo-webkom/db/serverless";
-import { eq } from "drizzle-orm";
+import { insertUserSchema } from "@echo-webkom/db/schemas";
 import { z } from "zod";
 
-import { auth } from "@/auth/session";
+import { UnoClient } from "@/api/uno/client";
+import { auth, getSessionToken } from "@/auth/session";
 import { sendVerificationEmail } from "@/lib/email-verification";
-import { isWebkom } from "@/lib/memberships";
 import { checkRateLimit } from "@/lib/rate-limit";
 
 const updateSelfPayloadSchema = insertUserSchema.pick({
@@ -36,29 +34,8 @@ export const updateSelf = async (payload: z.infer<typeof updateSelfPayloadSchema
     const newAlternativeEmail = data.alternativeEmail?.trim() || null;
     const isEmailChanging = user?.alternativeEmail !== newAlternativeEmail;
 
-    const resp = await db
-      .update(users)
-      .set({
-        alternativeEmail: newAlternativeEmail,
-        alternativeEmailVerifiedAt: isEmailChanging ? null : user.alternativeEmailVerifiedAt,
-        degreeId: data.degreeId,
-        year: data.year,
-        hasReadTerms: data.hasReadTerms,
-        birthday: data.birthday,
-        isPublic: data.isPublic,
-      })
-      .where(eq(users.id, user.id))
-      .returning()
-      .then((res) => res[0] ?? null);
-
-    if (!resp) {
-      return {
-        success: false,
-        message: "Fikk ikke til å oppdatere brukeren",
-      };
-    }
-
     // Send verification email if alternativeEmail was updated and is not null
+    // This must happen BEFORE the API call since it needs the old email data
     if (isEmailChanging && newAlternativeEmail) {
       // Rate limit: 3 attempts per hour per user
       const rateLimit = await checkRateLimit({
@@ -85,6 +62,36 @@ export const updateSelf = async (payload: z.infer<typeof updateSelfPayloadSchema
       }
     }
 
+    // Create a client with the user's session token for the API call
+    const sessionToken = await getSessionToken();
+    if (!sessionToken) {
+      return {
+        success: false,
+        message: "Noe gikk galt",
+      };
+    }
+
+    const unoClient = new UnoClient({
+      baseUrl: process.env.NEXT_PUBLIC_API_URL,
+      token: sessionToken,
+    });
+
+    const response = await unoClient.users.update(user.id, {
+      alternativeEmail: newAlternativeEmail,
+      degreeId: data.degreeId,
+      year: data.year,
+      hasReadTerms: data.hasReadTerms,
+      birthday: data.birthday,
+      isPublic: data.isPublic,
+    });
+
+    if (!response.success) {
+      return {
+        success: false,
+        message: "Fikk ikke til å oppdatere brukeren",
+      };
+    }
+
     return {
       success: true,
       message: "Brukeren ble oppdatert",
@@ -100,52 +107,6 @@ export const updateSelf = async (payload: z.infer<typeof updateSelfPayloadSchema
     return {
       success: false,
       message: "En feil har oppstått",
-    };
-  }
-};
-
-const updateUserPayloadSchema = z.object({
-  memberships: z.array(z.string()),
-});
-
-export const updateUser = async (
-  userId: string,
-  payload: z.infer<typeof updateUserPayloadSchema>,
-) => {
-  try {
-    const user = await auth();
-
-    if (user === null || !isWebkom(user)) {
-      return {
-        success: false,
-        message: "Du er ikke logget inn som en admin",
-      };
-    }
-
-    const data = await updateUserPayloadSchema.parseAsync(payload);
-
-    await db.delete(usersToGroups).where(eq(usersToGroups.userId, userId));
-    if (data.memberships.length > 0) {
-      await db
-        .insert(usersToGroups)
-        .values(data.memberships.map((groupId) => ({ userId, groupId })));
-    }
-
-    return {
-      success: true,
-      message: "Bruker oppdatert",
-    };
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        success: false,
-        message: "Tilbakemeldingen er ikke i riktig format",
-      };
-    }
-
-    return {
-      result: "error",
-      message: "Something went wrong",
     };
   }
 };

--- a/apps/web/src/api/uno/client.ts
+++ b/apps/web/src/api/uno/client.ts
@@ -1330,6 +1330,15 @@ interface BanInfo {
   };
 }
 
+export interface UserUpdatePayload {
+  alternativeEmail?: string | null;
+  degreeId?: string | null;
+  year?: number | null;
+  hasReadTerms?: boolean | null;
+  birthday?: Date | null;
+  isPublic?: boolean | null;
+}
+
 class UsersApi {
   private client: UnoClient;
 
@@ -1358,6 +1367,14 @@ class UsersApi {
     return await this.client.requestJson<Array<UserRegistration>>(
       "GET",
       `users/${userId}/registrations`,
+    );
+  }
+
+  async update(userId: string, payload: UserUpdatePayload) {
+    return await this.client.requestJson<{ success: boolean; message: string }>(
+      "PATCH",
+      `users/${userId}`,
+      payload,
     );
   }
 

--- a/apps/web/src/app/(default)/admin/brukere/user-form.tsx
+++ b/apps/web/src/app/(default)/admin/brukere/user-form.tsx
@@ -8,7 +8,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { type z } from "zod";
 
-import { updateUser } from "@/actions/user";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -31,6 +30,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
+import { useUnoClient } from "@/providers/uno";
 
 import { type AllUsers } from "./page";
 import { userFormSchema } from "./schemas";
@@ -42,6 +42,7 @@ type UserFormProps = {
 
 export const UserForm = ({ user, groups }: UserFormProps) => {
   const router = useRouter();
+  const unoClient = useUnoClient();
   const [isLoading, setIsLoading] = useState(false);
 
   const form = useForm<z.infer<typeof userFormSchema>>({
@@ -54,17 +55,31 @@ export const UserForm = ({ user, groups }: UserFormProps) => {
   const onSubmit = form.handleSubmit(async (data) => {
     setIsLoading(true);
 
-    const { success, message } = await updateUser(user.id, data);
+    try {
+      const currentMembershipIds = new Set(user.groups.map((g) => g.id));
+      const newMembershipIds = new Set(data.memberships);
 
-    setIsLoading(false);
+      // Add user to new groups
+      for (const groupId of data.memberships) {
+        if (!currentMembershipIds.has(groupId)) {
+          await unoClient.groups.addUser(groupId, user.id);
+        }
+      }
 
-    if (success) {
-      toast.success(message);
-    } else {
-      toast.error(message);
+      // Remove user from removed groups
+      for (const groupId of user.groups.map((g) => g.id)) {
+        if (!newMembershipIds.has(groupId)) {
+          await unoClient.groups.removeUser(groupId, user.id);
+        }
+      }
+
+      toast.success("Brukeren ble oppdatert");
+    } catch {
+      toast.error("Kunne ikke oppdatere brukeren");
+    } finally {
+      setIsLoading(false);
+      router.refresh();
     }
-
-    router.refresh();
   });
 
   return (

--- a/apps/web/src/app/(default)/hjem/page.tsx
+++ b/apps/web/src/app/(default)/hjem/page.tsx
@@ -14,6 +14,7 @@ import { FPCalendar } from "./_components/fp-calendar";
 import { HyggkomList } from "./_components/hyggkom-list";
 import { JobAds } from "./_components/job-ads";
 import { Posts } from "./_components/posts";
+import { WebathonBanner } from "./_components/webathon-banner";
 
 export default async function Home() {
   await ensureUser();

--- a/apps/web/src/app/(default)/hjem/page.tsx
+++ b/apps/web/src/app/(default)/hjem/page.tsx
@@ -14,7 +14,6 @@ import { FPCalendar } from "./_components/fp-calendar";
 import { HyggkomList } from "./_components/hyggkom-list";
 import { JobAds } from "./_components/job-ads";
 import { Posts } from "./_components/posts";
-import { WebathonBanner } from "./_components/webathon-banner";
 
 export default async function Home() {
   await ensureUser();

--- a/packages/db/scripts/reset.ts
+++ b/packages/db/scripts/reset.ts
@@ -9,12 +9,14 @@ async function main() {
 
 main()
   .then(() => {
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.log("✅ Database reset completed.");
     process.exit(0);
   })
   .catch((error) => {
+    // oxlint-disable-next-line no-console
     console.log("❌ Error resetting database:", error);
+    // oxlint-disable-next-line no-console
     console.log("Most likely nothing to reset. Continuing...");
     process.exit(0);
   });


### PR DESCRIPTION
- **refactor(feide): use centralized config for UNO base URL**
- **refactor: set session token in web**
- **feat: add user profile update endpoint with validation**
- **refactor(web): migrate user updates to uno api client**
