### PR TITLE
feat: vim keybinds to global search

### DIFF
--- a/apps/web/src/components/global-search.tsx
+++ b/apps/web/src/components/global-search.tsx
@@ -207,7 +207,7 @@ export const GlobalSearch = () => {
       />
       <div
         className={cn(
-          "fixed top-[18%] left-1/2 z-50 flex w-full max-w-3xl -translate-x-1/2 flex-col gap-2",
+          "fixed top-[18%] left-1/2 z-50 flex w-full max-w-3xl px-4 -translate-x-1/2 flex-col gap-2",
           "animate-in fade-in-0 zoom-in-95 duration-150",
         )}
       >

--- a/apps/web/src/components/global-search.tsx
+++ b/apps/web/src/components/global-search.tsx
@@ -156,18 +156,40 @@ export const GlobalSearch = () => {
     if (!isOpen) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
+      // Escape -> close
       if (e.key === "Escape") {
         setIsOpen(false);
-      } else if (e.key === "ArrowDown") {
+      }
+
+      // ArrowDown -> scroll down
+      if (e.key === "ArrowDown") {
         e.preventDefault();
         setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
-      } else if (e.key === "ArrowUp") {
+      }
+
+      // ArrowUp -> scroll up
+      if (e.key === "ArrowUp") {
         e.preventDefault();
         setSelectedIndex((i) => Math.max(i - 1, 0));
-      } else if (e.key === "Enter" && results.length > 0) {
+      }
+
+      // Enter -> navigate to selected
+      if (e.key === "Enter" && results.length > 0) {
         e.preventDefault();
         router.push(results[clampedIndex]?.href ?? "");
         setIsOpen(false);
+      }
+
+      // Ctrl-j -> scroll down
+      if (e.key === "j" && e.ctrlKey) {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+      }
+
+      // Ctrl-k -> scroll up
+      if (e.key === "k" && e.ctrlKey) {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
       }
     };
 


### PR DESCRIPTION
- **feat(global-search): add vim keybindings (ctrl-j/ctrl-k)**
- **style(global-search): add padding to sides**

Paddingen er bare sånn at søk ikke røren sidene av skjermen på mindre skjermer, typ når man tester mobile view på pcen. veldig minor greie.
