### PR TITLE
Endpoint for validating session

### DIFF
--- a/apps/uno/docs/docs.go
+++ b/apps/uno/docs/docs.go
@@ -209,6 +209,33 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Check session",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/callback/feide": {
             "get": {
                 "tags": [

--- a/apps/uno/docs/swagger.json
+++ b/apps/uno/docs/swagger.json
@@ -202,6 +202,33 @@
                 }
             }
         },
+        "/auth": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Check session",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/callback/feide": {
             "get": {
                 "tags": [

--- a/apps/uno/docs/swagger.yaml
+++ b/apps/uno/docs/swagger.yaml
@@ -1479,6 +1479,22 @@ paths:
       summary: Get Advent of Code leaderboard
       tags:
       - advent_of_code
+  /auth:
+    get:
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Check session
+      tags:
+      - auth
   /auth/callback/feide:
     get:
       parameters:

--- a/apps/uno/http/routes/api/auth.go
+++ b/apps/uno/http/routes/api/auth.go
@@ -47,6 +47,8 @@ func NewAuthMux(
 		userService: userService,
 	}
 
+	mux.GET("/", h.check, sessionMiddleware)
+
 	mux.GET("/me", h.getCurrentUser, sessionMiddleware)
 	mux.POST("/sign-out", h.signOut, sessionMiddleware)
 	mux.GET("/magic-link/verify", h.verifyMagicLink)
@@ -61,6 +63,17 @@ func NewAuthMux(
 	mux.GET("/sessions/{id}", h.getSessionByID, admin)
 
 	return mux
+}
+
+// check simply returns status 200, allowing external apps to validate session tokens.
+// @Summary      Check session
+// @Tags         auth
+// @Security     BearerAuth
+// @Success      200  {string}  string  "OK"
+// @Failure      401  {string}  string  "Unauthorized"
+// @Router       /auth [get]
+func (h *auth) check(ctx *handler.Context) error {
+	return ctx.Ok()
 }
 
 // loginWithFeide redirects the user to the Feide login page


### PR DESCRIPTION
* La til endepunkt /auth som bare returnerner 200 OK (med auth middleware)
* Dette er for å lage en enkel auth validation i unogo som backends kan bruke for å validate session cookies uten å f.eks hente hele brukere