### PR TITLE
oppdatert hva som vises med barstatus, og lagt til vaffelstatus på he…

### DIFF
--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -20,18 +20,32 @@ import { UserMenu } from "./user-menu";
 const getProgrammerbarStatus = async () => {
   try {
     return (await fetch("https://programmer.bar/api/status").then((res) => res.json())) as {
+      status: number;
       message: string;
     };
   } catch {
     return {
+      status: null,
       message: "",
     };
   }
 };
 
+const getVaffelStatus = async () => {
+  try {
+    return await fetch("https://vaffel.echo-webkom.no/687650156262195217/status").then((res) =>
+      res.text(),
+    );
+  } catch {
+    return "closed";
+  }
+};
+
 export const SiteHeader = async () => {
   const user = await auth();
-  const { message: progbarStatus } = await getProgrammerbarStatus();
+  const { status: progBarStatus, message: progbarMessage } = await getProgrammerbarStatus();
+
+  const vaffelStatus: string = await getVaffelStatus();
   const randomMessage = getRandomMessage();
 
   return (
@@ -54,7 +68,10 @@ export const SiteHeader = async () => {
                 ) : (
                   <Chip className="z-50">{randomMessage.text}</Chip>
                 )}
-                {progbarStatus !== "" && <Chip className="z-50">{progbarStatus}</Chip>}
+                {progBarStatus !== 0 && <Chip className="z-50">{progbarMessage}</Chip>}
+                {!vaffelStatus.includes("closed") && (
+                  <Chip className="z-50">{"Vaffel-botten er åpen 🧇"}</Chip>
+                )}
               </div>
 
               <div className="flex items-center">


### PR DESCRIPTION
Header pillene skal nå lytte til status på progBar API. Hvis status er 0 (stengt bar) skal vi ikke vise pillen, ellers vise pillen.

når vaffel-bot status er open skal en pille med vaffelstatus komme opp

<img width="1470" height="956" alt="bilde" src="https://github.com/user-attachments/assets/ad8cd315-7777-45e6-a433-dd445e6e9ad5" />

<img width="1470" height="956" alt="bilde" src="https://github.com/user-attachments/assets/2d8a4069-30f2-4fd7-b635-39e8cd4c9e73" />
