### PR TITLE
chore: unoptimize images

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,6 +19,8 @@ const config = {
   },
 
   images: {
+    unoptimized: true,
+
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Unoptimizer alle `<Image />`.

Jeg lurer på om det høyre minne-forburket kommer av at vi ikke hadde `sharp` installert. Så om vi opplever at dette funker dårlig, eller at vi trenger å optimize bildene kan man prøve å laste ned `sharp`.
